### PR TITLE
View v1 to v2 conversion

### DIFF
--- a/src/conversion/view-v1-to-v2.js
+++ b/src/conversion/view-v1-to-v2.js
@@ -41,7 +41,7 @@ function customRenderer (renderer, cell) {
 }
 
 function convertRenderer (cell) {
-  const {renderer} = cell 
+  const {renderer} = cell
   if (renderer === undefined) {
     return
   }
@@ -56,7 +56,7 @@ function convertRenderer (cell) {
     case 'textarea':
     default:
       return customRenderer(renderer, cell)
-    }
+  }
 }
 
 function grabClassNames (cell) {

--- a/src/conversion/view-v1-to-v2.js
+++ b/src/conversion/view-v1-to-v2.js
@@ -3,10 +3,23 @@ import _ from 'lodash'
 const CARRY_OVER_PROPERTIES = ['label', 'dependsOn', 'description', 'disabled', 'model', 'placeholder']
 const ARRAY_CELL_PROPERTIES = ['autoAdd', 'compact', 'showLabel', 'sortable']
 
+/**
+ * Turns rootContainers from V1 view into cells in v2 view
+ *
+ * @export
+ * @param {Object[]} rootContainers Containers to convert
+ * @returns {object[]} Array of cells converted from rootContainers
+ */
 export function generateCells (rootContainers) {
   return _.chain(rootContainers).flattenDeep().map(convertCell).filter().value()
 }
 
+/**
+ * Converts an complex container cell for an object into a v2 cell
+ *
+ * @param {object} cell Cell that should display an object
+ * @returns {object} Cell converted to v2
+ */
 function convertObjectCell (cell) {
   return _.chain(cell.rows)
   .map(rowsToCells)
@@ -14,6 +27,12 @@ function convertObjectCell (cell) {
   .value()
 }
 
+/**
+ * Converts a container cell that displays an array into a v2 cell
+ *
+ * @param {object} cell Cell that should display an array
+ * @returns {object} Cell converted to v2
+ */
 function convertArrayCell (cell) {
   const {item} = cell
   const arrayOptions = _.chain(item)
@@ -28,12 +47,25 @@ function convertArrayCell (cell) {
   }
 }
 
-function customRenderer (renderer, cell) {
+/**
+ * Creates custom renderer information for a cell
+ *
+ * @param {string} renderer Name of the desired renderer
+ * @param {object} properties Info for to the custom renderer
+ * @returns {object} Custom renderer block
+ */
+function customRenderer (renderer, properties) {
   return _.assign({
     name: renderer
-  }, cell.properties)
+  }, properties)
 }
 
+/**
+ * Converts v1 renderer information to v2 for a cell
+ *
+ * @param {object} cell Cell with a custom renderer
+ * @returns {object} Custom renderer block for the given cell
+ */
 function convertRenderer (cell) {
   const {renderer} = cell
   if (renderer === undefined) {
@@ -49,10 +81,16 @@ function convertRenderer (cell) {
     case 'multi-select':
     case 'textarea':
     default:
-      return customRenderer(renderer, cell)
+      return customRenderer(renderer, cell.properties)
   }
 }
 
+/**
+ * Creates class name block for v2 cell
+ *
+ * @param {object} cell Cell to get class names from
+ * @returns {object} Class name block for the cell
+ */
 function grabClassNames (cell) {
   const classNames = _.pickBy({
     cell: cell.className,
@@ -64,12 +102,25 @@ function grabClassNames (cell) {
   }
 }
 
+/**
+ * Converts a cell for simple data type (e.g. string, or number)
+ *
+ * @param {object} cell Cell in v1 to convert to v2
+ * @returns {object} Cell converted to v2
+ */
 function convertBasicCell (cell) {
   return _.pickBy(_.assign({
     renderer: convertRenderer(cell)
   }, _.pick(cell, CARRY_OVER_PROPERTIES)))
 }
 
+/**
+ * Determines which cell conversion function to use to convert v1 cell to v2 and converts it
+ *
+ * @export
+ * @param {object} cell A v1 cell to convert to v2
+ * @returns {object} The cell converted to v2
+ */
 export function convertCell (cell) {
   let cellConverter
   if (cell.item) {
@@ -86,6 +137,12 @@ export function convertCell (cell) {
   }, cellConverter(cell)))
 }
 
+/**
+ * Converts rows of v1 cells to v2 cells. Simplifies the row structure when possible.
+ *
+ * @param {object[][]} rows A set of rows to convert
+ * @returns {object} A v2 cell
+ */
 function rowsToCells (rows) {
   const collapseRows = !_.some(rows, function (row) {
     return row.length > 1
@@ -110,6 +167,13 @@ function rowsToCells (rows) {
   }
 }
 
+/**
+ * Converts the container declarations in a v1 view to cell definitions in a v2 view
+ *
+ * @export
+ * @param {object[]} containers Set of containers to convert
+ * @returns {object} cell definitions for the v2 view.
+ */
 export function generateCellDefinitions (containers) {
   return _.chain(containers)
   .map(function (container) {
@@ -120,6 +184,13 @@ export function generateCellDefinitions (containers) {
   .value()
 }
 
+/**
+ * Converts a bunsen version 1 view into a bunsen/ui schema version 2 view
+ *
+ * @export
+ * @param {any} v1View A v1 view to convert to v2
+ * @returns {object} The v2 view generated from the given v1 view
+ */
 export default function viewV1ToV2 (v1View) {
   const {type} = v1View
 

--- a/tests/conversion/view-v1-to-v2-test.js
+++ b/tests/conversion/view-v1-to-v2-test.js
@@ -76,6 +76,8 @@ addFullTest('handles more complex views', 'array-view')
 
 addFullTest('converts renderer info', 'custom-renderers-view')
 
+addFullTest('collapses rows when possible', 'collapsed-rows-view')
+
 function runTest (unitUnderTest, testData, testNumber) {
   var expectedResult = testData.expectedResult
   var description = testData.description

--- a/tests/conversion/view-v1-to-v2-test.js
+++ b/tests/conversion/view-v1-to-v2-test.js
@@ -61,18 +61,20 @@ const CELL_TEST1 = {
     }
   }
 }
-
-const FULL_TEST1 = {
-  description: 'converts a v1 view into a v2 view',
-  inputs: [inputFixture('simple-view')],
-  expectedResult: resultFixture('simple-view')
+const FULL_TESTS = []
+function addFullTest (description, fixtureName) {
+  FULL_TESTS.push({
+    description,
+    inputs: [inputFixture(fixtureName)],
+    expectedResult: resultFixture(fixtureName)
+  })
 }
 
-const FULL_TEST2 = {
-  description: 'handles more complex views',
-  inputs: [inputFixture('array-view')],
-  expectedResult: resultFixture('array-view')
-}
+addFullTest('converts a v1 view into a v2 view', 'simple-view')
+
+addFullTest('handles more complex views', 'array-view')
+
+addFullTest('converts renderer info', 'custom-renderers-view')
 
 function runTest (unitUnderTest, testData, testNumber) {
   var expectedResult = testData.expectedResult
@@ -103,9 +105,5 @@ describe('generateCell', function () {
 })
 
 describe('Bunsen view version 1 to view version 2 conversion', function () {
-  const tests = [
-    FULL_TEST1,
-    FULL_TEST2
-  ]
-  _.each(tests, _.partial(runTest, viewV1toV2))
+  _.each(FULL_TESTS, _.partial(runTest, viewV1toV2))
 })

--- a/tests/conversion/view-v1-to-v2-test.js
+++ b/tests/conversion/view-v1-to-v2-test.js
@@ -32,12 +32,8 @@ const CELL_DEF_TEST1 = {
   ],
   expectedResult: {
     test: {
-      children: [
-        {
-          model: 'some-property',
-          extends: 'someContainer'
-        }
-      ]
+      model: 'some-property',
+      extends: 'someContainer'
     }
   }
 }

--- a/tests/fixtures/collapsed-rows-view.js
+++ b/tests/fixtures/collapsed-rows-view.js
@@ -20,7 +20,7 @@ module.exports = {
         {
           children: [
             {
-              model: 'item-2-2'
+              model: 'item-2-1'
             }
           ]
         },
@@ -67,6 +67,9 @@ module.exports = {
           model: 'item-4'
         }
       ]
+    },
+    'total-collapse': {
+      model: 'top-level-item'
     }
   },
   cells: [
@@ -78,6 +81,9 @@ module.exports = {
     },
     {
       extends: 'multi-row-collapse'
+    },
+    {
+      extends: 'total-collapse'
     }
   ]
 }

--- a/tests/fixtures/collapsed-rows-view.js
+++ b/tests/fixtures/collapsed-rows-view.js
@@ -1,0 +1,83 @@
+module.exports = {
+  type: 'form',
+  version: '2.0',
+  cellDefinitions: {
+    'uncollapsed-rows': {
+      children: [
+        {
+          children: [
+            {
+              model: 'item-1-1'
+            },
+            {
+              model: 'item-1-2'
+            },
+            {
+              model: 'item-1-3'
+            }
+          ]
+        },
+        {
+          children: [
+            {
+              model: 'item-2-2'
+            }
+          ]
+        },
+        {
+          children: [
+            {
+              model: 'item-3-1'
+            },
+            {
+              model: 'item-3-2'
+            },
+            {
+              model: 'item-3-3'
+            },
+            {
+              model: 'item-3-4'
+            }
+          ]
+        }
+      ]
+    },
+    'one-row-collapse': {
+      children: [
+        {
+          model: 'item-1'
+        }, {
+          model: 'item-2'
+        }, {
+          model: 'item-3'
+        }, {
+          model: 'item-4'
+        }
+      ]
+    },
+    'multi-row-collapse': {
+      children: [
+        {
+          model: 'item-1'
+        }, {
+          model: 'item-2'
+        }, {
+          model: 'item-3'
+        }, {
+          model: 'item-4'
+        }
+      ]
+    }
+  },
+  cells: [
+    {
+      extends: 'uncollapsed-rows'
+    },
+    {
+      extends: 'one-row-collapse'
+    },
+    {
+      extends: 'multi-row-collapse'
+    }
+  ]
+}

--- a/tests/fixtures/custom-renderers-view.js
+++ b/tests/fixtures/custom-renderers-view.js
@@ -10,23 +10,22 @@ module.exports = {
     bar: {
       children: [
         {
-          model: 'barChild1',
-          renderer: {
-            name: 'textarea'
-          }
+          extends: 'barChild1'
         },
         {
           extends: 'barChild2'
         }
       ]
     },
+    barChild1: {
+      model: 'barChild1',
+      renderer: {
+        name: 'textarea'
+      }
+    },
     barChild2: {
-      children: [
-        {
-          model: 'barChild2',
-          extends: 'barGrandChildren'
-        }
-      ]
+      model: 'barChild2',
+      extends: 'barGrandChildren'
     },
     barGrandChildren: {
       children: [

--- a/tests/fixtures/custom-renderers-view.js
+++ b/tests/fixtures/custom-renderers-view.js
@@ -10,51 +10,39 @@ module.exports = {
     bar: {
       children: [
         {
-          extends: 'barChild1'
+          model: 'barChild1',
+          renderer: {
+            name: 'textarea'
+          }
         },
         {
           extends: 'barChild2'
         }
       ]
     },
-    barChild1: {
-      model: 'barChild1',
-      renderer: {
-        name: 'textarea'
-      }
-    },
     barChild2: {
-      model: 'barChild2',
       children: [
         {
-          extends: 'barGrandChild'
-        },
-        {
-          extends: 'barOtherGrandChild'
+          model: 'barChild2',
+          extends: 'barGrandChildren'
         }
       ]
     },
     barGrandChildren: {
       children: [
         {
-          extends: 'barGrandChild'
+          model: 'barGrandChild',
+          renderer: {
+            name: 'custom1'
+          }
         },
         {
-          extends: 'barOtherGrandChild'
+          model: 'barOtherGrandChild',
+          renderer: {
+            name: 'custom2'
+          }
         }
       ]
-    },
-    barGrandChild: {
-      model: 'barGrandChild',
-      renderer: {
-        name: 'custom1'
-      }
-    },
-    otherGrandChild: {
-      model: 'barOtherGrandChild',
-      renderer: {
-        name: 'custom2'
-      }
     },
     baz: {
       model: 'baz',
@@ -73,6 +61,10 @@ module.exports = {
     {
       extends: 'bar',
       model: 'bar'
+    },
+    {
+      extends: 'baz',
+      model: 'baz'
     }
   ]
 }

--- a/tests/fixtures/custom-renderers-view.js
+++ b/tests/fixtures/custom-renderers-view.js
@@ -1,0 +1,78 @@
+module.exports = {
+  type: 'form',
+  version: '2.0',
+  cellDefinitions: {
+    foo: {
+      renderer: {
+        name: 'select'
+      }
+    },
+    bar: {
+      children: [
+        {
+          extends: 'barChild1'
+        },
+        {
+          extends: 'barChild2'
+        }
+      ]
+    },
+    barChild1: {
+      model: 'barChild1',
+      renderer: {
+        name: 'textarea'
+      }
+    },
+    barChild2: {
+      model: 'barChild2',
+      children: [
+        {
+          extends: 'barGrandChild'
+        },
+        {
+          extends: 'barOtherGrandChild'
+        }
+      ]
+    },
+    barGrandChildren: {
+      children: [
+        {
+          extends: 'barGrandChild'
+        },
+        {
+          extends: 'barOtherGrandChild'
+        }
+      ]
+    },
+    barGrandChild: {
+      model: 'barGrandChild',
+      renderer: {
+        name: 'custom1'
+      }
+    },
+    otherGrandChild: {
+      model: 'barOtherGrandChild',
+      renderer: {
+        name: 'custom2'
+      }
+    },
+    baz: {
+      model: 'baz',
+      renderer: {
+        name: 'custom-renderer',
+        someProp: 45,
+        otherProp: false
+      }
+    }
+  },
+  cells: [
+    {
+      extends: 'foo',
+      model: 'foo'
+    },
+    {
+      extends: 'bar',
+      model: 'bar'
+    }
+  ]
+}

--- a/tests/fixtures/v1-views/collapsed-rows-view-v1.js
+++ b/tests/fixtures/v1-views/collapsed-rows-view-v1.js
@@ -1,0 +1,72 @@
+module.exports = {
+  type: 'form',
+  version: '1.0',
+  containers: [
+    {
+      id: 'uncollapsed-rows',
+      rows: [
+        [
+          {
+            model: 'item-1-1'
+          }, {
+            model: 'item-1-2'
+          }, {
+            model: 'item-1-3'
+          }
+        ], [
+          {
+            model: 'item-2-1'
+          }
+        ], [
+          {
+            model: 'item-3-1'
+          },
+          {
+            model: 'item-3-2'
+          },
+          {
+            model: 'item-3-3'
+          },
+          {
+            model: 'item-3-4'
+          }
+        ]
+      ]
+    },
+    {
+      id: 'one-row-collapse',
+      rows: [[{
+        model: 'item-1'
+      }, {
+        model: 'item-2'
+      }, {
+        model: 'item-3'
+      }, {
+        model: 'item-4'
+      }]]
+    },
+    {
+      id: 'multi-row-collapse',
+      rows: [[{
+        model: 'item-1'
+      }], [{
+        model: 'item-2'
+      }], [{
+        model: 'item-3'
+      }], [{
+        model: 'item-4'
+      }]]
+    }
+  ],
+  rootContainers: [
+    {
+      container: 'uncollapsed-rows'
+    },
+    {
+      container: 'one-row-collapse'
+    },
+    {
+      container: 'multi-row-collapse'
+    }
+  ]
+}

--- a/tests/fixtures/v1-views/collapsed-rows-view-v1.js
+++ b/tests/fixtures/v1-views/collapsed-rows-view-v1.js
@@ -56,6 +56,12 @@ module.exports = {
       }], [{
         model: 'item-4'
       }]]
+    },
+    {
+      id: 'total-collapse',
+      rows: [[{
+        model: 'top-level-item'
+      }]]
     }
   ],
   rootContainers: [
@@ -67,6 +73,9 @@ module.exports = {
     },
     {
       container: 'multi-row-collapse'
+    },
+    {
+      container: 'total-collapse'
     }
   ]
 }

--- a/tests/fixtures/v1-views/custom-renderers-view-v1.js
+++ b/tests/fixtures/v1-views/custom-renderers-view-v1.js
@@ -4,7 +4,11 @@ module.exports = {
   containers: [
     {
       id: 'foo',
-      renderer: 'select'
+      rows: [[
+        {
+          renderer: 'select'
+        }
+      ]]
     },
     {
       id: 'bar',
@@ -52,12 +56,14 @@ module.exports = {
     },
     {
       id: 'baz',
-      model: 'baz',
-      renderer: 'custom-renderer',
-      properties: {
-        someProp: 45,
-        otherProp: false
-      }
+      rows: [[{
+        model: 'baz',
+        renderer: 'custom-renderer',
+        properties: {
+          someProp: 45,
+          otherProp: false
+        }
+      }]]
     }
   ],
   rootContainers: [
@@ -68,6 +74,10 @@ module.exports = {
     {
       container: 'bar',
       model: 'bar'
+    },
+    {
+      container: 'baz',
+      model: 'baz'
     }
   ]
 }

--- a/tests/fixtures/v1-views/custom-renderers-view-v1.js
+++ b/tests/fixtures/v1-views/custom-renderers-view-v1.js
@@ -1,0 +1,73 @@
+module.exports = {
+  type: 'form',
+  version: '1.0',
+  containers: [
+    {
+      id: 'foo',
+      renderer: 'select'
+    },
+    {
+      id: 'bar',
+      rows: [
+        [
+          {
+            container: 'barChild1'
+          },
+          {
+            container: 'barChild2'
+          }
+        ]
+      ]
+    },
+    {
+      id: 'barChild1',
+      rows: [
+        [{
+          model: 'barChild1',
+          render: 'textArea'
+        }]
+      ]
+    },
+    {
+      id: 'barChild2',
+      rows: [
+        [{
+          model: 'barChild2',
+          container: 'barGrandChildren'
+        }]
+      ]
+    },
+    {
+      id: 'barGrandChildren',
+      rows: [
+        [{
+          model: 'barGrandChild',
+          renderer: 'custom1'
+        }],
+        [{
+          model: 'barOtherGrandChild',
+          renderer: 'custom2'
+        }]
+      ]
+    },
+    {
+      id: 'baz',
+      model: 'baz',
+      renderer: 'custom-renderer',
+      properties: {
+        someProp: 45,
+        otherProp: false
+      }
+    }
+  ],
+  rootContainers: [
+    {
+      container: 'foo',
+      model: 'foo'
+    },
+    {
+      container: 'bar',
+      model: 'bar'
+    }
+  ]
+}

--- a/tests/fixtures/v1-views/custom-renderers-view-v1.js
+++ b/tests/fixtures/v1-views/custom-renderers-view-v1.js
@@ -28,7 +28,7 @@ module.exports = {
       rows: [
         [{
           model: 'barChild1',
-          render: 'textArea'
+          renderer: 'textarea'
         }]
       ]
     },

--- a/tests/fixtures/v1-views/simple-view-v1.js
+++ b/tests/fixtures/v1-views/simple-view-v1.js
@@ -6,7 +6,8 @@ module.exports = {
       label: 'Main',
       container: 'main'
     }
-  ], containers: [
+  ],
+  containers: [
     {
       id: 'main',
       rows: [


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Added tests for view v1 to v2 conversion
- Rows will now be collapsed when possble
- Fixed some cases of complex object view conversion.
