### PR TITLE
fix bug in validation

### DIFF
--- a/src/validator/cell.js
+++ b/src/validator/cell.js
@@ -215,8 +215,8 @@ export default createFactory({
       results.push(
         this._validateSubCell(`${path}/extends`, cell.extends, model)
       )
-    } else {
-      addErrorResult(results, path, 'Either "model" or "extends" must be defined for each cell.')
+    } else if (!cell.children) {
+      addErrorResult(results, path, '"children", "extends", or "model" must be defined for each cell.')
     }
 
     const knownAttributes = _.keys(viewSchema.definitions.cell.properties)

--- a/tests/validator/cell-test.js
+++ b/tests/validator/cell-test.js
@@ -141,7 +141,7 @@ describe('validator/cell', () => {
             },
             {
               path: '#/cellDefinitions/0/children/2',
-              message: 'Either "model" or "extends" must be defined for each cell.'
+              message: '"children", "extends", or "model" must be defined for each cell.'
             },
             {
               path: '#/cellDefinitions/0/children/3/model',


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** bug where a cell was being marked invalid when it had the `children` property but not `extends` or `model`.
