### PR TITLE
Added padding to get correct number of bits

### DIFF
--- a/src/validator/custom-formats/utils.js
+++ b/src/validator/custom-formats/utils.js
@@ -9,8 +9,10 @@ export const networkMaskMin = 0
 export function decimalToBinary (decimal) {
   // NOTE: we are applying two's complement so we can properly represent negative
   // numbers in binary. See: https://en.wikipedia.org/wiki/Two%27s_complement
+  const PAD = '00000000'
   const twosComplement = decimal >>> 0
-  return twosComplement.toString(2)
+  const binaryStr = twosComplement.toString(2)
+  return PAD.substring(binaryStr.length) + binaryStr
 }
 
 /**

--- a/tests/validator/custom-formats/ipv4-prefix-test.js
+++ b/tests/validator/custom-formats/ipv4-prefix-test.js
@@ -75,5 +75,6 @@ describe('validator/custom-formats/ipv4-prefix', () => {
 
   it('returns true when valid IPv4 prefix', () => {
     expect(ipv4Prefix('192.168.0.0/16')).to.be.true
+    expect(ipv4Prefix('192.168.104.0/24')).to.be.true
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Fixed ipv4-prefix format validation
