### PR TITLE
Add ipv6-address and ip-address formats

### DIFF
--- a/src/validator/custom-formats/ip-address.js
+++ b/src/validator/custom-formats/ip-address.js
@@ -1,17 +1,18 @@
 /**
  * @reference https://en.wikipedia.org/wiki/IPv4
+ * @reference https://en.wikipedia.org/wiki/IPv6
  */
 
 import validator from 'validator'
 
 /**
- * Validate value as an IPv4 address
+ * Validate value as an IP address (can be IPv4 or IPv6)
  * @param {Any} value - value to validate
  * @returns {Boolean} whether or not value is valid
  */
 export default function (value) {
   try {
-    return validator.isIP(value, 4)
+    return validator.isIP(value)
   } catch (err) {
     return false
   }

--- a/src/validator/custom-formats/ipv6-address.js
+++ b/src/validator/custom-formats/ipv6-address.js
@@ -1,17 +1,17 @@
 /**
- * @reference https://en.wikipedia.org/wiki/IPv4
+ * @reference https://en.wikipedia.org/wiki/IPv6
  */
 
 import validator from 'validator'
 
 /**
- * Validate value as an IPv4 address
+ * Validate value as an IPv6 address
  * @param {Any} value - value to validate
  * @returns {Boolean} whether or not value is valid
  */
 export default function (value) {
   try {
-    return validator.isIP(value, 4)
+    return validator.isIP(value, 6)
   } catch (err) {
     return false
   }

--- a/tests/validator/custom-formats/ip-address-test.js
+++ b/tests/validator/custom-formats/ip-address-test.js
@@ -1,0 +1,141 @@
+const expect = require('chai').expect
+
+const ipAddress = require('../../../lib/validator/custom-formats/ip-address')
+
+describe('validator/custom-formats/ip-address', () => {
+  describe('IPv4', function () {
+    it('returns false when value is undefined', () => {
+      expect(ipAddress(undefined)).to.be.false
+    })
+
+    it('returns false when value is null', () => {
+      expect(ipAddress(null)).to.be.false
+    })
+
+    it('returns false when value is an object', () => {
+      expect(ipAddress({})).to.be.false
+    })
+
+    it('returns false when value is an array', () => {
+      expect(ipAddress([])).to.be.false
+    })
+
+    it('returns false when value is an integer', () => {
+      expect(ipAddress(1)).to.be.false
+    })
+
+    it('returns false when value is a float', () => {
+      expect(ipAddress(0.5)).to.be.false
+    })
+
+    it('returns false when value is NaN', () => {
+      expect(ipAddress(NaN)).to.be.false
+    })
+
+    it('returns false when value is Infinity', () => {
+      expect(ipAddress(Infinity)).to.be.false
+    })
+
+    it('returns false when value does not consist of four octets', () => {
+      expect(ipAddress('100.101.102')).to.be.false
+    })
+
+    it('returns false when octets contain non-numeric characters', () => {
+      expect(ipAddress('100a.101.102.103')).to.be.false
+      expect(ipAddress('100.101a.102.103')).to.be.false
+      expect(ipAddress('100.101.102a.103')).to.be.false
+      expect(ipAddress('100.101.102.103a')).to.be.false
+    })
+
+    it('returns false when octets contain negative numbers', () => {
+      expect(ipAddress('-100.101.102.103')).to.be.false
+      expect(ipAddress('100.-101.102.103')).to.be.false
+      expect(ipAddress('100.101.-102.103')).to.be.false
+      expect(ipAddress('100.101.102.-103')).to.be.false
+    })
+
+    it('returns false when octets contain numbers > 255', () => {
+      expect(ipAddress('256.101.102.103')).to.be.false
+      expect(ipAddress('100.256.102.103')).to.be.false
+      expect(ipAddress('100.101.256.103')).to.be.false
+      expect(ipAddress('100.101.102.256')).to.be.false
+    })
+
+    it('returns true when valid IPv4 address', () => {
+      expect(ipAddress('0.0.0.0')).to.be.true
+      expect(ipAddress('127.0.0.1')).to.be.true
+      expect(ipAddress('255.255.255.255')).to.be.true
+    })
+  })
+
+  describe('IPv6', function () {
+    it('returns false when value is undefined', () => {
+      expect(ipAddress(undefined)).to.be.false
+    })
+
+    it('returns false when value is null', () => {
+      expect(ipAddress(null)).to.be.false
+    })
+
+    it('returns false when value is an object', () => {
+      expect(ipAddress({})).to.be.false
+    })
+
+    it('returns false when value is an array', () => {
+      expect(ipAddress([])).to.be.false
+    })
+
+    it('returns false when value is an integer', () => {
+      expect(ipAddress(1)).to.be.false
+    })
+
+    it('returns false when value is a float', () => {
+      expect(ipAddress(0.5)).to.be.false
+    })
+
+    it('returns false when value is NaN', () => {
+      expect(ipAddress(NaN)).to.be.false
+    })
+
+    it('returns false when value is Infinity', () => {
+      expect(ipAddress(Infinity)).to.be.false
+    })
+
+    it('returns false when value does not consist of eight groups', () => {
+      expect(ipAddress('0000')).to.be.false
+      expect(ipAddress('0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000')).to.be.false
+    })
+
+    it('returns false when groups contain non-hex characters', () => {
+      expect(ipAddress('000g:0000:0000:0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:000g:0000:0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:000g:0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:000g:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:000g:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000:000g:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:000g:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:000g')).to.be.false
+    })
+
+    it('returns false when groups contain negative numbers', () => {
+      expect(ipAddress('-0001:0000:0000:0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:-0001:0000:0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:-0001:0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:-0001:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:-0001:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000:-0001:0000:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:-0001:0000')).to.be.false
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:-0001')).to.be.false
+    })
+
+    it('returns true when valid IPv6 address', () => {
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.true
+      expect(ipAddress('2001:0db8:0000:0042:0000:8a2e:0370:7334')).to.be.true
+    })
+  })
+})

--- a/tests/validator/custom-formats/ipv4-address-test.js
+++ b/tests/validator/custom-formats/ipv4-address-test.js
@@ -60,13 +60,6 @@ describe('validator/custom-formats/ipv4-address', () => {
     expect(ipv4Address('100.101.102.256')).to.be.false
   })
 
-  it('returns false when octet has leading zeros', () => {
-    expect(ipv4Address('01.1.1.1')).to.be.false
-    expect(ipv4Address('1.01.1.1')).to.be.false
-    expect(ipv4Address('1.1.01.1')).to.be.false
-    expect(ipv4Address('1.1.1.01')).to.be.false
-  })
-
   it('returns true when valid IPv4 address', () => {
     expect(ipv4Address('0.0.0.0')).to.be.true
     expect(ipv4Address('127.0.0.1')).to.be.true

--- a/tests/validator/custom-formats/ipv6-address-test.js
+++ b/tests/validator/custom-formats/ipv6-address-test.js
@@ -1,0 +1,74 @@
+const expect = require('chai').expect
+
+const ipv6Address = require('../../../lib/validator/custom-formats/ipv6-address')
+
+describe('validator/custom-formats/ipv6-address', () => {
+  it('returns false when value is undefined', () => {
+    expect(ipv6Address(undefined)).to.be.false
+  })
+
+  it('returns false when value is null', () => {
+    expect(ipv6Address(null)).to.be.false
+  })
+
+  it('returns false when value is an object', () => {
+    expect(ipv6Address({})).to.be.false
+  })
+
+  it('returns false when value is an array', () => {
+    expect(ipv6Address([])).to.be.false
+  })
+
+  it('returns false when value is an integer', () => {
+    expect(ipv6Address(1)).to.be.false
+  })
+
+  it('returns false when value is a float', () => {
+    expect(ipv6Address(0.5)).to.be.false
+  })
+
+  it('returns false when value is NaN', () => {
+    expect(ipv6Address(NaN)).to.be.false
+  })
+
+  it('returns false when value is Infinity', () => {
+    expect(ipv6Address(Infinity)).to.be.false
+  })
+
+  it('returns false when value does not consist of eight groups', () => {
+    expect(ipv6Address('0000')).to.be.false
+    expect(ipv6Address('0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000')).to.be.false
+  })
+
+  it('returns false when groups contain non-hex characters', () => {
+    expect(ipv6Address('000g:0000:0000:0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:000g:0000:0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:000g:0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:000g:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:000g:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000:000g:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:000g:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:000g')).to.be.false
+  })
+
+  it('returns false when groups contain negative numbers', () => {
+    expect(ipv6Address('-0001:0000:0000:0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:-0001:0000:0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:-0001:0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:-0001:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:-0001:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000:-0001:0000:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:-0001:0000')).to.be.false
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:-0001')).to.be.false
+  })
+
+  it('returns true when valid IPv6 address', () => {
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.true
+    expect(ipv6Address('2001:0db8:0000:0042:0000:8a2e:0370:7334')).to.be.true
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** two new formats: `ip-address` and `ipv6-address`.
- **Fixed** `ipv4-address` format to accept octets with preceding zeros.
