### PR TITLE
Actually expose new formats

### DIFF
--- a/src/validator/custom-formats/index.js
+++ b/src/validator/custom-formats/index.js
@@ -5,9 +5,11 @@ import int8 from './int8'
 import int16 from './int16'
 import int32 from './int32'
 import int64 from './int64'
+import ipAddress from './ip-address'
 import ipv4Address from './ipv4-address'
 import ipv4Interface from './ipv4-interface'
 import ipv4Prefix from './ipv4-prefix'
+import ipv6Address from './ipv6-address'
 import netmask from './netmask'
 import portNumber from './port-number'
 import time from './time'
@@ -25,9 +27,11 @@ export default {
   int16,
   int32,
   int64,
+  'ip-address': ipAddress,
   'ipv4-address': ipv4Address,
   'ipv4-interface': ipv4Interface,
   'ipv4-prefix': ipv4Prefix,
+  'ipv6-address': ipv6Address,
   netmask,
   'port-number': portNumber,
   time,


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** code to actually expose `ip-address` and `ipv6-address` custom formats to consumer.
