### PR TITLE
Swap to.be.true for to.be.equal(true)

### DIFF
--- a/tests/validator/custom-formats/bgp-as-test.js
+++ b/tests/validator/custom-formats/bgp-as-test.js
@@ -4,73 +4,73 @@ const bgpAs = require('../../../lib/validator/custom-formats/bgp-as')
 
 describe('validator/custom-formats/bgp-as', () => {
   it('returns false when value is undefined', () => {
-    expect(bgpAs(undefined)).to.be.false
+    expect(bgpAs(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(bgpAs(null)).to.be.false
+    expect(bgpAs(null)).to.be.equal(false)
   })
 
   it('returns false when value is a string', () => {
-    expect(bgpAs('test')).to.be.false
+    expect(bgpAs('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(bgpAs({})).to.be.false
+    expect(bgpAs({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(bgpAs([])).to.be.false
+    expect(bgpAs([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(bgpAs(0.5)).to.be.false
+    expect(bgpAs(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(bgpAs(NaN)).to.be.false
+    expect(bgpAs(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(bgpAs(Infinity)).to.be.false
+    expect(bgpAs(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value < 0', () => {
-    expect(bgpAs(-1)).to.be.false
-    expect(bgpAs('-1')).to.be.false
+    expect(bgpAs(-1)).to.be.equal(false)
+    expect(bgpAs('-1')).to.be.equal(false)
   })
 
   it('returns false when value = 0', () => {
-    expect(bgpAs(0)).to.be.false
-    expect(bgpAs('0')).to.be.false
+    expect(bgpAs(0)).to.be.equal(false)
+    expect(bgpAs('0')).to.be.equal(false)
   })
 
   it('returns true when 1 <= value <= 65534', () => {
-    expect(bgpAs(1)).to.be.true
-    expect(bgpAs('1')).to.be.true
-    expect(bgpAs(65534)).to.be.true
-    expect(bgpAs('65534')).to.be.true
+    expect(bgpAs(1)).to.be.equal(true)
+    expect(bgpAs('1')).to.be.equal(true)
+    expect(bgpAs(65534)).to.be.equal(true)
+    expect(bgpAs('65534')).to.be.equal(true)
   })
 
   it('returns false when value = 65535', () => {
-    expect(bgpAs(65535)).to.be.false
-    expect(bgpAs('65535')).to.be.false
+    expect(bgpAs(65535)).to.be.equal(false)
+    expect(bgpAs('65535')).to.be.equal(false)
   })
 
   it('returns true when 65536 <= value <= 4294967294', () => {
-    expect(bgpAs(65536)).to.be.true
-    expect(bgpAs('65536')).to.be.true
-    expect(bgpAs(4294967294)).to.be.true
-    expect(bgpAs('4294967294')).to.be.true
+    expect(bgpAs(65536)).to.be.equal(true)
+    expect(bgpAs('65536')).to.be.equal(true)
+    expect(bgpAs(4294967294)).to.be.equal(true)
+    expect(bgpAs('4294967294')).to.be.equal(true)
   })
 
   it('returns false when value = 4294967295', () => {
-    expect(bgpAs(4294967295)).to.be.false
-    expect(bgpAs('4294967295')).to.be.false
+    expect(bgpAs(4294967295)).to.be.equal(false)
+    expect(bgpAs('4294967295')).to.be.equal(false)
   })
 
   it('returns false when value > 4294967295', () => {
-    expect(bgpAs(4294967296)).to.be.false
-    expect(bgpAs('4294967296')).to.be.false
+    expect(bgpAs(4294967296)).to.be.equal(false)
+    expect(bgpAs('4294967296')).to.be.equal(false)
   })
 })

--- a/tests/validator/custom-formats/date-test.js
+++ b/tests/validator/custom-formats/date-test.js
@@ -4,134 +4,134 @@ const date = require('../../../lib/validator/custom-formats/date')
 
 describe('validator/custom-formats/date', () => {
   it('returns false when value is undefined', () => {
-    expect(date(undefined)).to.be.false
+    expect(date(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(date(null)).to.be.false
+    expect(date(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(date({})).to.be.false
+    expect(date({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(date([])).to.be.false
+    expect(date([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(date(0.5)).to.be.false
+    expect(date(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(date(NaN)).to.be.false
+    expect(date(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(date(Infinity)).to.be.false
+    expect(date(Infinity)).to.be.equal(false)
   })
 
   it('returns true when value is in format MMMM DD YYYY', () => {
-    expect(date('August 03 2015')).to.be.true
+    expect(date('August 03 2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format MMMM D YYYY', () => {
-    expect(date('August 3 2015')).to.be.true
+    expect(date('August 3 2015')).to.be.equal(true)
   })
 
   /* FIXME: this test passes in Chrome but fails in Firefox
   it('returns true when value is in format MMMM DD YY', () => {
-    expect(date('August 03 15')).to.be.true
+    expect(date('August 03 15')).to.be.equal(true)
   })
   */
 
   /* FIXME: this test passes in Chrome but fails in Firefox
   it('returns true when value is in format MMMM D YY', () => {
-    expect(date('August 3 15')).to.be.true
+    expect(date('August 3 15')).to.be.equal(true)
   })
   */
 
   it('returns true when value is in format MMM DD YYYY', () => {
-    expect(date('Aug 03 2015')).to.be.true
+    expect(date('Aug 03 2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format MMM D YYYY', () => {
-    expect(date('Aug 3 2015')).to.be.true
+    expect(date('Aug 3 2015')).to.be.equal(true)
   })
 
   /* FIXME: this test passes in Chrome but fails in Firefox
   it('returns true when value is in format MMM DD YY', () => {
-    expect(date('Aug 03 15')).to.be.true
+    expect(date('Aug 03 15')).to.be.equal(true)
   })
   */
 
   /* FIXME: this test passes in Chrome but fails in Firefox
   it('returns true when value is in format MMM D YY', () => {
-    expect(date('Aug 3 15')).to.be.true
+    expect(date('Aug 3 15')).to.be.equal(true)
   })
   */
 
   it('returns true when value is in format MM DD YYYY', () => {
-    expect(date('08 03 2015')).to.be.true
+    expect(date('08 03 2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format MM D YYYY', () => {
-    expect(date('08 3 2015')).to.be.true
+    expect(date('08 3 2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format MM DD YY', () => {
-    expect(date('08 03 15')).to.be.true
+    expect(date('08 03 15')).to.be.equal(true)
   })
 
   it('returns true when value is in format MM D YY', () => {
-    expect(date('08 3 15')).to.be.true
+    expect(date('08 3 15')).to.be.equal(true)
   })
 
   it('returns true when value is in format M DD YYYY', () => {
-    expect(date('8 03 2015')).to.be.true
+    expect(date('8 03 2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format M D YYYY', () => {
-    expect(date('8 3 2015')).to.be.true
+    expect(date('8 3 2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format M DD YY', () => {
-    expect(date('8 03 15')).to.be.true
+    expect(date('8 03 15')).to.be.equal(true)
   })
 
   it('returns true when value is in format M D YY', () => {
-    expect(date('8 3 15')).to.be.true
+    expect(date('8 3 15')).to.be.equal(true)
   })
 
   it('returns true when value is in format MM/DD/YYYY', () => {
-    expect(date('08/03/2015')).to.be.true
+    expect(date('08/03/2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format MM/D/YYYY', () => {
-    expect(date('08/3/2015')).to.be.true
+    expect(date('08/3/2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format MM/DD/YY', () => {
-    expect(date('08/03/15')).to.be.true
+    expect(date('08/03/15')).to.be.equal(true)
   })
 
   it('returns true when value is in format MM/D/YY', () => {
-    expect(date('08/3/15')).to.be.true
+    expect(date('08/3/15')).to.be.equal(true)
   })
 
   it('returns true when value is in format M/DD/YYYY', () => {
-    expect(date('8/03/2015')).to.be.true
+    expect(date('8/03/2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format M/D/YYYY', () => {
-    expect(date('8/3/2015')).to.be.true
+    expect(date('8/3/2015')).to.be.equal(true)
   })
 
   it('returns true when value is in format M/DD/YY', () => {
-    expect(date('8/03/15')).to.be.true
+    expect(date('8/03/15')).to.be.equal(true)
   })
 
   it('returns true when value is in format M/D/YY', () => {
-    expect(date('8/3/15')).to.be.true
+    expect(date('8/3/15')).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/hex-string-test.js
+++ b/tests/validator/custom-formats/hex-string-test.js
@@ -4,35 +4,35 @@ const hexString = require('../../../lib/validator/custom-formats/hex-string')
 
 describe('validator/custom-formats/hex-string', () => {
   it('returns false when value is undefined', () => {
-    expect(hexString(undefined)).to.be.false
+    expect(hexString(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(hexString(null)).to.be.false
+    expect(hexString(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(hexString({})).to.be.false
+    expect(hexString({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(hexString([])).to.be.false
+    expect(hexString([])).to.be.equal(false)
   })
 
   it('returns false when value is an integer', () => {
-    expect(hexString(1)).to.be.false
+    expect(hexString(1)).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(hexString(0.5)).to.be.false
+    expect(hexString(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(hexString(NaN)).to.be.false
+    expect(hexString(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(hexString(Infinity)).to.be.false
+    expect(hexString(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value is not valid', () => {
@@ -44,7 +44,7 @@ describe('validator/custom-formats/hex-string', () => {
       'g1'
     ]
       .forEach((value) => {
-        expect(hexString(value)).to.be.false
+        expect(hexString(value)).to.be.equal(false)
       })
   })
 
@@ -55,7 +55,7 @@ describe('validator/custom-formats/hex-string', () => {
       'f1'
     ]
       .forEach((value) => {
-        expect(hexString(value)).to.be.true
+        expect(hexString(value)).to.be.equal(true)
       })
   })
 })

--- a/tests/validator/custom-formats/int16-test.js
+++ b/tests/validator/custom-formats/int16-test.js
@@ -4,51 +4,51 @@ const int16 = require('../../../lib/validator/custom-formats/int16')
 
 describe('validator/custom-formats/int16', () => {
   it('returns false when value is undefined', () => {
-    expect(int16(undefined)).to.be.false
+    expect(int16(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(int16(null)).to.be.false
+    expect(int16(null)).to.be.equal(false)
   })
 
   it('returns false when value is a non-numeric string', () => {
-    expect(int16('test')).to.be.false
+    expect(int16('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(int16({})).to.be.false
+    expect(int16({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(int16([])).to.be.false
+    expect(int16([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(int16(0.5)).to.be.false
+    expect(int16(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(int16(NaN)).to.be.false
+    expect(int16(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(int16(Infinity)).to.be.false
+    expect(int16(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value < -32768', () => {
-    expect(int16(-32769)).to.be.false
-    expect(int16('-32769')).to.be.false
+    expect(int16(-32769)).to.be.equal(false)
+    expect(int16('-32769')).to.be.equal(false)
   })
 
   it('returns true when -32768 <= value <= 32767', () => {
-    expect(int16(-32768)).to.be.true
-    expect(int16('-32768')).to.be.true
-    expect(int16(32767)).to.be.true
-    expect(int16('32767')).to.be.true
+    expect(int16(-32768)).to.be.equal(true)
+    expect(int16('-32768')).to.be.equal(true)
+    expect(int16(32767)).to.be.equal(true)
+    expect(int16('32767')).to.be.equal(true)
   })
 
   it('returns false when value > 32767', () => {
-    expect(int16(32768)).to.be.false
-    expect(int16('32768')).to.be.false
+    expect(int16(32768)).to.be.equal(false)
+    expect(int16('32768')).to.be.equal(false)
   })
 })

--- a/tests/validator/custom-formats/int32-test.js
+++ b/tests/validator/custom-formats/int32-test.js
@@ -4,55 +4,55 @@ const int32 = require('../../../lib/validator/custom-formats/int32')
 
 describe('validator/custom-formats/int32', () => {
   it('returns false when value is undefined', () => {
-    expect(int32(undefined)).to.be.false
+    expect(int32(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(int32(null)).to.be.false
+    expect(int32(null)).to.be.equal(false)
   })
 
   it('returns false when value is a non-numeric string', () => {
-    expect(int32('test')).to.be.false
+    expect(int32('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(int32({})).to.be.false
+    expect(int32({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(int32([])).to.be.false
+    expect(int32([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(int32(0.5)).to.be.false
+    expect(int32(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(int32(NaN)).to.be.false
+    expect(int32(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(int32(Infinity)).to.be.false
+    expect(int32(Infinity)).to.be.equal(false)
   })
 
   it('returns true when value is an integer', () => {
-    expect(int32(0)).to.be.true
+    expect(int32(0)).to.be.equal(true)
   })
 
   it('returns false when value < -2147483648', () => {
-    expect(int32(-2147483649)).to.be.false
-    expect(int32('-2147483649')).to.be.false
+    expect(int32(-2147483649)).to.be.equal(false)
+    expect(int32('-2147483649')).to.be.equal(false)
   })
 
   it('returns true when -2147483648 <= value <= 2147483647', () => {
-    expect(int32(-2147483648)).to.be.true
-    expect(int32('-2147483648')).to.be.true
-    expect(int32(2147483647)).to.be.true
-    expect(int32('2147483647')).to.be.true
+    expect(int32(-2147483648)).to.be.equal(true)
+    expect(int32('-2147483648')).to.be.equal(true)
+    expect(int32(2147483647)).to.be.equal(true)
+    expect(int32('2147483647')).to.be.equal(true)
   })
 
   it('returns false when value > 2147483647', () => {
-    expect(int32(2147483648)).to.be.false
-    expect(int32('2147483648')).to.be.false
+    expect(int32(2147483648)).to.be.equal(false)
+    expect(int32('2147483648')).to.be.equal(false)
   })
 })

--- a/tests/validator/custom-formats/int64-test.js
+++ b/tests/validator/custom-formats/int64-test.js
@@ -4,38 +4,38 @@ const int64 = require('../../../lib/validator/custom-formats/int64')
 
 describe('validator/custom-formats/int64', () => {
   it('returns false when value is undefined', () => {
-    expect(int64(undefined)).to.be.false
+    expect(int64(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(int64(null)).to.be.false
+    expect(int64(null)).to.be.equal(false)
   })
 
   it('returns false when value is a non-numeric string', () => {
-    expect(int64('test')).to.be.false
+    expect(int64('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(int64({})).to.be.false
+    expect(int64({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(int64([])).to.be.false
+    expect(int64([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(int64(0.5)).to.be.false
+    expect(int64(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(int64(NaN)).to.be.false
+    expect(int64(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(int64(Infinity)).to.be.false
+    expect(int64(Infinity)).to.be.equal(false)
   })
 
   it('returns true when value is an integer', () => {
-    expect(int64(0)).to.be.true
+    expect(int64(0)).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/int8-test.js
+++ b/tests/validator/custom-formats/int8-test.js
@@ -4,51 +4,51 @@ const int8 = require('../../../lib/validator/custom-formats/int8')
 
 describe('validator/custom-formats/int8', () => {
   it('returns false when value is undefined', () => {
-    expect(int8(undefined)).to.be.false
+    expect(int8(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(int8(null)).to.be.false
+    expect(int8(null)).to.be.equal(false)
   })
 
   it('returns false when value is a non-numeric string', () => {
-    expect(int8('test')).to.be.false
+    expect(int8('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(int8({})).to.be.false
+    expect(int8({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(int8([])).to.be.false
+    expect(int8([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(int8(0.5)).to.be.false
+    expect(int8(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(int8(NaN)).to.be.false
+    expect(int8(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(int8(Infinity)).to.be.false
+    expect(int8(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value < -128', () => {
-    expect(int8(-129)).to.be.false
-    expect(int8('-129')).to.be.false
+    expect(int8(-129)).to.be.equal(false)
+    expect(int8('-129')).to.be.equal(false)
   })
 
   it('returns true when -128 <= value <= 127', () => {
-    expect(int8(-128)).to.be.true
-    expect(int8('-128')).to.be.true
-    expect(int8(127)).to.be.true
-    expect(int8('127')).to.be.true
+    expect(int8(-128)).to.be.equal(true)
+    expect(int8('-128')).to.be.equal(true)
+    expect(int8(127)).to.be.equal(true)
+    expect(int8('127')).to.be.equal(true)
   })
 
   it('returns false when value > 127', () => {
-    expect(int8(128)).to.be.false
-    expect(int8('128')).to.be.false
+    expect(int8(128)).to.be.equal(false)
+    expect(int8('128')).to.be.equal(false)
   })
 })

--- a/tests/validator/custom-formats/ip-address-test.js
+++ b/tests/validator/custom-formats/ip-address-test.js
@@ -5,137 +5,137 @@ const ipAddress = require('../../../lib/validator/custom-formats/ip-address')
 describe('validator/custom-formats/ip-address', () => {
   describe('IPv4', function () {
     it('returns false when value is undefined', () => {
-      expect(ipAddress(undefined)).to.be.false
+      expect(ipAddress(undefined)).to.be.equal(false)
     })
 
     it('returns false when value is null', () => {
-      expect(ipAddress(null)).to.be.false
+      expect(ipAddress(null)).to.be.equal(false)
     })
 
     it('returns false when value is an object', () => {
-      expect(ipAddress({})).to.be.false
+      expect(ipAddress({})).to.be.equal(false)
     })
 
     it('returns false when value is an array', () => {
-      expect(ipAddress([])).to.be.false
+      expect(ipAddress([])).to.be.equal(false)
     })
 
     it('returns false when value is an integer', () => {
-      expect(ipAddress(1)).to.be.false
+      expect(ipAddress(1)).to.be.equal(false)
     })
 
     it('returns false when value is a float', () => {
-      expect(ipAddress(0.5)).to.be.false
+      expect(ipAddress(0.5)).to.be.equal(false)
     })
 
     it('returns false when value is NaN', () => {
-      expect(ipAddress(NaN)).to.be.false
+      expect(ipAddress(NaN)).to.be.equal(false)
     })
 
     it('returns false when value is Infinity', () => {
-      expect(ipAddress(Infinity)).to.be.false
+      expect(ipAddress(Infinity)).to.be.equal(false)
     })
 
     it('returns false when value does not consist of four octets', () => {
-      expect(ipAddress('100.101.102')).to.be.false
+      expect(ipAddress('100.101.102')).to.be.equal(false)
     })
 
     it('returns false when octets contain non-numeric characters', () => {
-      expect(ipAddress('100a.101.102.103')).to.be.false
-      expect(ipAddress('100.101a.102.103')).to.be.false
-      expect(ipAddress('100.101.102a.103')).to.be.false
-      expect(ipAddress('100.101.102.103a')).to.be.false
+      expect(ipAddress('100a.101.102.103')).to.be.equal(false)
+      expect(ipAddress('100.101a.102.103')).to.be.equal(false)
+      expect(ipAddress('100.101.102a.103')).to.be.equal(false)
+      expect(ipAddress('100.101.102.103a')).to.be.equal(false)
     })
 
     it('returns false when octets contain negative numbers', () => {
-      expect(ipAddress('-100.101.102.103')).to.be.false
-      expect(ipAddress('100.-101.102.103')).to.be.false
-      expect(ipAddress('100.101.-102.103')).to.be.false
-      expect(ipAddress('100.101.102.-103')).to.be.false
+      expect(ipAddress('-100.101.102.103')).to.be.equal(false)
+      expect(ipAddress('100.-101.102.103')).to.be.equal(false)
+      expect(ipAddress('100.101.-102.103')).to.be.equal(false)
+      expect(ipAddress('100.101.102.-103')).to.be.equal(false)
     })
 
     it('returns false when octets contain numbers > 255', () => {
-      expect(ipAddress('256.101.102.103')).to.be.false
-      expect(ipAddress('100.256.102.103')).to.be.false
-      expect(ipAddress('100.101.256.103')).to.be.false
-      expect(ipAddress('100.101.102.256')).to.be.false
+      expect(ipAddress('256.101.102.103')).to.be.equal(false)
+      expect(ipAddress('100.256.102.103')).to.be.equal(false)
+      expect(ipAddress('100.101.256.103')).to.be.equal(false)
+      expect(ipAddress('100.101.102.256')).to.be.equal(false)
     })
 
     it('returns true when valid IPv4 address', () => {
-      expect(ipAddress('0.0.0.0')).to.be.true
-      expect(ipAddress('127.0.0.1')).to.be.true
-      expect(ipAddress('255.255.255.255')).to.be.true
+      expect(ipAddress('0.0.0.0')).to.be.equal(true)
+      expect(ipAddress('127.0.0.1')).to.be.equal(true)
+      expect(ipAddress('255.255.255.255')).to.be.equal(true)
     })
   })
 
   describe('IPv6', function () {
     it('returns false when value is undefined', () => {
-      expect(ipAddress(undefined)).to.be.false
+      expect(ipAddress(undefined)).to.be.equal(false)
     })
 
     it('returns false when value is null', () => {
-      expect(ipAddress(null)).to.be.false
+      expect(ipAddress(null)).to.be.equal(false)
     })
 
     it('returns false when value is an object', () => {
-      expect(ipAddress({})).to.be.false
+      expect(ipAddress({})).to.be.equal(false)
     })
 
     it('returns false when value is an array', () => {
-      expect(ipAddress([])).to.be.false
+      expect(ipAddress([])).to.be.equal(false)
     })
 
     it('returns false when value is an integer', () => {
-      expect(ipAddress(1)).to.be.false
+      expect(ipAddress(1)).to.be.equal(false)
     })
 
     it('returns false when value is a float', () => {
-      expect(ipAddress(0.5)).to.be.false
+      expect(ipAddress(0.5)).to.be.equal(false)
     })
 
     it('returns false when value is NaN', () => {
-      expect(ipAddress(NaN)).to.be.false
+      expect(ipAddress(NaN)).to.be.equal(false)
     })
 
     it('returns false when value is Infinity', () => {
-      expect(ipAddress(Infinity)).to.be.false
+      expect(ipAddress(Infinity)).to.be.equal(false)
     })
 
     it('returns false when value does not consist of eight groups', () => {
-      expect(ipAddress('0000')).to.be.false
-      expect(ipAddress('0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000')).to.be.false
+      expect(ipAddress('0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
     })
 
     it('returns false when groups contain non-hex characters', () => {
-      expect(ipAddress('000g:0000:0000:0000:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:000g:0000:0000:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:000g:0000:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:000g:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:000g:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000:000g:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000:0000:000g:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:000g')).to.be.false
+      expect(ipAddress('000g:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:000g:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:000g:0000:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:000g:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:000g:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000:000g:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:000g:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:000g')).to.be.equal(false)
     })
 
     it('returns false when groups contain negative numbers', () => {
-      expect(ipAddress('-0001:0000:0000:0000:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:-0001:0000:0000:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:-0001:0000:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:-0001:0000:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:-0001:0000:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000:-0001:0000:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000:0000:-0001:0000')).to.be.false
-      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:-0001')).to.be.false
+      expect(ipAddress('-0001:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:-0001:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:-0001:0000:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:-0001:0000:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:-0001:0000:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000:-0001:0000:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:-0001:0000')).to.be.equal(false)
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:-0001')).to.be.equal(false)
     })
 
     it('returns true when valid IPv6 address', () => {
-      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.true
-      expect(ipAddress('2001:0db8:0000:0042:0000:8a2e:0370:7334')).to.be.true
+      expect(ipAddress('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(true)
+      expect(ipAddress('2001:0db8:0000:0042:0000:8a2e:0370:7334')).to.be.equal(true)
     })
   })
 })

--- a/tests/validator/custom-formats/ipv4-address-test.js
+++ b/tests/validator/custom-formats/ipv4-address-test.js
@@ -4,65 +4,65 @@ const ipv4Address = require('../../../lib/validator/custom-formats/ipv4-address'
 
 describe('validator/custom-formats/ipv4-address', () => {
   it('returns false when value is undefined', () => {
-    expect(ipv4Address(undefined)).to.be.false
+    expect(ipv4Address(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(ipv4Address(null)).to.be.false
+    expect(ipv4Address(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(ipv4Address({})).to.be.false
+    expect(ipv4Address({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(ipv4Address([])).to.be.false
+    expect(ipv4Address([])).to.be.equal(false)
   })
 
   it('returns false when value is an integer', () => {
-    expect(ipv4Address(1)).to.be.false
+    expect(ipv4Address(1)).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(ipv4Address(0.5)).to.be.false
+    expect(ipv4Address(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(ipv4Address(NaN)).to.be.false
+    expect(ipv4Address(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(ipv4Address(Infinity)).to.be.false
+    expect(ipv4Address(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value does not consist of four octets', () => {
-    expect(ipv4Address('100.101.102')).to.be.false
+    expect(ipv4Address('100.101.102')).to.be.equal(false)
   })
 
   it('returns false when octets contain non-numeric characters', () => {
-    expect(ipv4Address('100a.101.102.103')).to.be.false
-    expect(ipv4Address('100.101a.102.103')).to.be.false
-    expect(ipv4Address('100.101.102a.103')).to.be.false
-    expect(ipv4Address('100.101.102.103a')).to.be.false
+    expect(ipv4Address('100a.101.102.103')).to.be.equal(false)
+    expect(ipv4Address('100.101a.102.103')).to.be.equal(false)
+    expect(ipv4Address('100.101.102a.103')).to.be.equal(false)
+    expect(ipv4Address('100.101.102.103a')).to.be.equal(false)
   })
 
   it('returns false when octets contain negative numbers', () => {
-    expect(ipv4Address('-100.101.102.103')).to.be.false
-    expect(ipv4Address('100.-101.102.103')).to.be.false
-    expect(ipv4Address('100.101.-102.103')).to.be.false
-    expect(ipv4Address('100.101.102.-103')).to.be.false
+    expect(ipv4Address('-100.101.102.103')).to.be.equal(false)
+    expect(ipv4Address('100.-101.102.103')).to.be.equal(false)
+    expect(ipv4Address('100.101.-102.103')).to.be.equal(false)
+    expect(ipv4Address('100.101.102.-103')).to.be.equal(false)
   })
 
   it('returns false when octets contain numbers > 255', () => {
-    expect(ipv4Address('256.101.102.103')).to.be.false
-    expect(ipv4Address('100.256.102.103')).to.be.false
-    expect(ipv4Address('100.101.256.103')).to.be.false
-    expect(ipv4Address('100.101.102.256')).to.be.false
+    expect(ipv4Address('256.101.102.103')).to.be.equal(false)
+    expect(ipv4Address('100.256.102.103')).to.be.equal(false)
+    expect(ipv4Address('100.101.256.103')).to.be.equal(false)
+    expect(ipv4Address('100.101.102.256')).to.be.equal(false)
   })
 
   it('returns true when valid IPv4 address', () => {
-    expect(ipv4Address('0.0.0.0')).to.be.true
-    expect(ipv4Address('127.0.0.1')).to.be.true
-    expect(ipv4Address('255.255.255.255')).to.be.true
+    expect(ipv4Address('0.0.0.0')).to.be.equal(true)
+    expect(ipv4Address('127.0.0.1')).to.be.equal(true)
+    expect(ipv4Address('255.255.255.255')).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/ipv4-interface-test.js
+++ b/tests/validator/custom-formats/ipv4-interface-test.js
@@ -4,78 +4,78 @@ const ipv4Interface = require('../../../lib/validator/custom-formats/ipv4-interf
 
 describe('validator/custom-formats/ipv4-interface', () => {
   it('returns false when value is undefined', () => {
-    expect(ipv4Interface(undefined)).to.be.false
+    expect(ipv4Interface(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(ipv4Interface(null)).to.be.false
+    expect(ipv4Interface(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(ipv4Interface({})).to.be.false
+    expect(ipv4Interface({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(ipv4Interface([])).to.be.false
+    expect(ipv4Interface([])).to.be.equal(false)
   })
 
   it('returns false when value is an integer', () => {
-    expect(ipv4Interface(1)).to.be.false
+    expect(ipv4Interface(1)).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(ipv4Interface(0.5)).to.be.false
+    expect(ipv4Interface(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(ipv4Interface(NaN)).to.be.false
+    expect(ipv4Interface(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(ipv4Interface(Infinity)).to.be.false
+    expect(ipv4Interface(Infinity)).to.be.equal(false)
   })
 
   it('returns false when network mask is missing', () => {
-    expect(ipv4Interface('100.101.102.103')).to.be.false
+    expect(ipv4Interface('100.101.102.103')).to.be.equal(false)
   })
 
   it('returns false when ip address does not consist of four octets', () => {
-    expect(ipv4Interface('100.101.102/0')).to.be.false
+    expect(ipv4Interface('100.101.102/0')).to.be.equal(false)
   })
 
   it('returns false when octets contain non-numeric characters', () => {
-    expect(ipv4Interface('100a.101.102.103/0')).to.be.false
-    expect(ipv4Interface('100.101a.102.103/0')).to.be.false
-    expect(ipv4Interface('100.101.102a.103/0')).to.be.false
-    expect(ipv4Interface('100.101.102.103a/0')).to.be.false
+    expect(ipv4Interface('100a.101.102.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.101a.102.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.101.102a.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.101.102.103a/0')).to.be.equal(false)
   })
 
   it('returns false when octets contain negative numbers', () => {
-    expect(ipv4Interface('-100.101.102.103/0')).to.be.false
-    expect(ipv4Interface('100.-101.102.103/0')).to.be.false
-    expect(ipv4Interface('100.101.-102.103/0')).to.be.false
-    expect(ipv4Interface('100.101.102.-103/0')).to.be.false
+    expect(ipv4Interface('-100.101.102.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.-101.102.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.101.-102.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.101.102.-103/0')).to.be.equal(false)
   })
 
   it('returns false when octets contain numbers > 255', () => {
-    expect(ipv4Interface('256.101.102.103/0')).to.be.false
-    expect(ipv4Interface('100.256.102.103/0')).to.be.false
-    expect(ipv4Interface('100.101.256.103/0')).to.be.false
-    expect(ipv4Interface('100.101.102.256/0')).to.be.false
+    expect(ipv4Interface('256.101.102.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.256.102.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.101.256.103/0')).to.be.equal(false)
+    expect(ipv4Interface('100.101.102.256/0')).to.be.equal(false)
   })
 
   it('returns false when first octet contains numbers > 253', () => {
-    expect(ipv4Interface('254.0.0.0/0')).to.be.false
-    expect(ipv4Interface('255.0.0.0/0')).to.be.false
+    expect(ipv4Interface('254.0.0.0/0')).to.be.equal(false)
+    expect(ipv4Interface('255.0.0.0/0')).to.be.equal(false)
   })
 
   it('returns false when invalid IPv4 interface', () => {
-    expect(ipv4Interface('192.168.0.0/16')).to.be.false
-    expect(ipv4Interface('192.168.255.255/16')).to.be.false
+    expect(ipv4Interface('192.168.0.0/16')).to.be.equal(false)
+    expect(ipv4Interface('192.168.255.255/16')).to.be.equal(false)
   })
 
   it('returns true when valid IPv4 interface', () => {
-    expect(ipv4Interface('192.168.128.0/16')).to.be.true
-    expect(ipv4Interface('192.168.0.1/16')).to.be.true
+    expect(ipv4Interface('192.168.128.0/16')).to.be.equal(true)
+    expect(ipv4Interface('192.168.0.1/16')).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/ipv4-prefix-test.js
+++ b/tests/validator/custom-formats/ipv4-prefix-test.js
@@ -4,77 +4,77 @@ const ipv4Prefix = require('../../../lib/validator/custom-formats/ipv4-prefix')
 
 describe('validator/custom-formats/ipv4-prefix', () => {
   it('returns false when value is undefined', () => {
-    expect(ipv4Prefix(undefined)).to.be.false
+    expect(ipv4Prefix(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(ipv4Prefix(null)).to.be.false
+    expect(ipv4Prefix(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(ipv4Prefix({})).to.be.false
+    expect(ipv4Prefix({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(ipv4Prefix([])).to.be.false
+    expect(ipv4Prefix([])).to.be.equal(false)
   })
 
   it('returns false when value is an integer', () => {
-    expect(ipv4Prefix(1)).to.be.false
+    expect(ipv4Prefix(1)).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(ipv4Prefix(0.5)).to.be.false
+    expect(ipv4Prefix(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(ipv4Prefix(NaN)).to.be.false
+    expect(ipv4Prefix(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(ipv4Prefix(Infinity)).to.be.false
+    expect(ipv4Prefix(Infinity)).to.be.equal(false)
   })
 
   it('returns false when network mask is missing', () => {
-    expect(ipv4Prefix('100.101.102.103')).to.be.false
+    expect(ipv4Prefix('100.101.102.103')).to.be.equal(false)
   })
 
   it('returns false when ip address does not consist of four octets', () => {
-    expect(ipv4Prefix('100.101.102/0')).to.be.false
+    expect(ipv4Prefix('100.101.102/0')).to.be.equal(false)
   })
 
   it('returns false when octets contain non-numeric characters', () => {
-    expect(ipv4Prefix('100a.101.102.103/0')).to.be.false
-    expect(ipv4Prefix('100.101a.102.103/0')).to.be.false
-    expect(ipv4Prefix('100.101.102a.103/0')).to.be.false
-    expect(ipv4Prefix('100.101.102.103a/0')).to.be.false
+    expect(ipv4Prefix('100a.101.102.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.101a.102.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.101.102a.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.101.102.103a/0')).to.be.equal(false)
   })
 
   it('returns false when octets contain negative numbers', () => {
-    expect(ipv4Prefix('-100.101.102.103/0')).to.be.false
-    expect(ipv4Prefix('100.-101.102.103/0')).to.be.false
-    expect(ipv4Prefix('100.101.-102.103/0')).to.be.false
-    expect(ipv4Prefix('100.101.102.-103/0')).to.be.false
+    expect(ipv4Prefix('-100.101.102.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.-101.102.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.101.-102.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.101.102.-103/0')).to.be.equal(false)
   })
 
   it('returns false when octets contain numbers > 255', () => {
-    expect(ipv4Prefix('256.101.102.103/0')).to.be.false
-    expect(ipv4Prefix('100.256.102.103/0')).to.be.false
-    expect(ipv4Prefix('100.101.256.103/0')).to.be.false
-    expect(ipv4Prefix('100.101.102.256/0')).to.be.false
+    expect(ipv4Prefix('256.101.102.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.256.102.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.101.256.103/0')).to.be.equal(false)
+    expect(ipv4Prefix('100.101.102.256/0')).to.be.equal(false)
   })
 
   it('returns false when first octet contains numbers > 253', () => {
-    expect(ipv4Prefix('254.0.0.0/0')).to.be.false
-    expect(ipv4Prefix('255.0.0.0/0')).to.be.false
+    expect(ipv4Prefix('254.0.0.0/0')).to.be.equal(false)
+    expect(ipv4Prefix('255.0.0.0/0')).to.be.equal(false)
   })
 
   it('returns false when invalid IPv4 prefix', () => {
-    expect(ipv4Prefix('192.168.128.0/16')).to.be.false
+    expect(ipv4Prefix('192.168.128.0/16')).to.be.equal(false)
   })
 
   it('returns true when valid IPv4 prefix', () => {
-    expect(ipv4Prefix('192.168.0.0/16')).to.be.true
-    expect(ipv4Prefix('192.168.104.0/24')).to.be.true
+    expect(ipv4Prefix('192.168.0.0/16')).to.be.equal(true)
+    expect(ipv4Prefix('192.168.104.0/24')).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/ipv6-address-test.js
+++ b/tests/validator/custom-formats/ipv6-address-test.js
@@ -4,71 +4,71 @@ const ipv6Address = require('../../../lib/validator/custom-formats/ipv6-address'
 
 describe('validator/custom-formats/ipv6-address', () => {
   it('returns false when value is undefined', () => {
-    expect(ipv6Address(undefined)).to.be.false
+    expect(ipv6Address(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(ipv6Address(null)).to.be.false
+    expect(ipv6Address(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(ipv6Address({})).to.be.false
+    expect(ipv6Address({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(ipv6Address([])).to.be.false
+    expect(ipv6Address([])).to.be.equal(false)
   })
 
   it('returns false when value is an integer', () => {
-    expect(ipv6Address(1)).to.be.false
+    expect(ipv6Address(1)).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(ipv6Address(0.5)).to.be.false
+    expect(ipv6Address(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(ipv6Address(NaN)).to.be.false
+    expect(ipv6Address(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(ipv6Address(Infinity)).to.be.false
+    expect(ipv6Address(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value does not consist of eight groups', () => {
-    expect(ipv6Address('0000')).to.be.false
-    expect(ipv6Address('0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000')).to.be.false
+    expect(ipv6Address('0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
   })
 
   it('returns false when groups contain non-hex characters', () => {
-    expect(ipv6Address('000g:0000:0000:0000:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:000g:0000:0000:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:000g:0000:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:000g:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:000g:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000:000g:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000:0000:000g:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:000g')).to.be.false
+    expect(ipv6Address('000g:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:000g:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:000g:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:000g:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:000g:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000:000g:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:000g:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:000g')).to.be.equal(false)
   })
 
   it('returns false when groups contain negative numbers', () => {
-    expect(ipv6Address('-0001:0000:0000:0000:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:-0001:0000:0000:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:-0001:0000:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:-0001:0000:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:-0001:0000:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000:-0001:0000:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000:0000:-0001:0000')).to.be.false
-    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:-0001')).to.be.false
+    expect(ipv6Address('-0001:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:-0001:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:-0001:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:-0001:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:-0001:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000:-0001:0000:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:-0001:0000')).to.be.equal(false)
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:-0001')).to.be.equal(false)
   })
 
   it('returns true when valid IPv6 address', () => {
-    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.true
-    expect(ipv6Address('2001:0db8:0000:0042:0000:8a2e:0370:7334')).to.be.true
+    expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(true)
+    expect(ipv6Address('2001:0db8:0000:0042:0000:8a2e:0370:7334')).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/netmask-test.js
+++ b/tests/validator/custom-formats/netmask-test.js
@@ -4,71 +4,71 @@ const netmask = require('../../../lib/validator/custom-formats/netmask')
 
 describe('validator/custom-formats/ipv4-address', () => {
   it('returns false when value is undefined', () => {
-    expect(netmask(undefined)).to.be.false
+    expect(netmask(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(netmask(null)).to.be.false
+    expect(netmask(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(netmask({})).to.be.false
+    expect(netmask({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(netmask([])).to.be.false
+    expect(netmask([])).to.be.equal(false)
   })
 
   it('returns false when value is an integer', () => {
-    expect(netmask(1)).to.be.false
+    expect(netmask(1)).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(netmask(0.5)).to.be.false
+    expect(netmask(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(netmask(NaN)).to.be.false
+    expect(netmask(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(netmask(Infinity)).to.be.false
+    expect(netmask(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value does not consist of four octets', () => {
-    expect(netmask('100.101.102')).to.be.false
+    expect(netmask('100.101.102')).to.be.equal(false)
   })
 
   it('returns false when octets contain non-numeric characters', () => {
-    expect(netmask('100a.101.102.103')).to.be.false
-    expect(netmask('100.101a.102.103')).to.be.false
-    expect(netmask('100.101.102a.103')).to.be.false
-    expect(netmask('100.101.102.103a')).to.be.false
+    expect(netmask('100a.101.102.103')).to.be.equal(false)
+    expect(netmask('100.101a.102.103')).to.be.equal(false)
+    expect(netmask('100.101.102a.103')).to.be.equal(false)
+    expect(netmask('100.101.102.103a')).to.be.equal(false)
   })
 
   it('returns false when octets contain negative numbers', () => {
-    expect(netmask('-100.101.102.103')).to.be.false
-    expect(netmask('100.-101.102.103')).to.be.false
-    expect(netmask('100.101.-102.103')).to.be.false
-    expect(netmask('100.101.102.-103')).to.be.false
+    expect(netmask('-100.101.102.103')).to.be.equal(false)
+    expect(netmask('100.-101.102.103')).to.be.equal(false)
+    expect(netmask('100.101.-102.103')).to.be.equal(false)
+    expect(netmask('100.101.102.-103')).to.be.equal(false)
   })
 
   it('returns false when octets contain numbers > 255', () => {
-    expect(netmask('256.101.102.103')).to.be.false
-    expect(netmask('100.256.102.103')).to.be.false
-    expect(netmask('100.101.256.103')).to.be.false
-    expect(netmask('100.101.102.256')).to.be.false
+    expect(netmask('256.101.102.103')).to.be.equal(false)
+    expect(netmask('100.256.102.103')).to.be.equal(false)
+    expect(netmask('100.101.256.103')).to.be.equal(false)
+    expect(netmask('100.101.102.256')).to.be.equal(false)
   })
 
   it('returns false when invalid netmask', () => {
-    expect(netmask('127.0.0.1')).to.be.false
-    expect(netmask('255.255.255.144')).to.be.false
+    expect(netmask('127.0.0.1')).to.be.equal(false)
+    expect(netmask('255.255.255.144')).to.be.equal(false)
   })
 
   it('returns true when valid netmask', () => {
-    expect(netmask('0.0.0.0')).to.be.true
-    expect(netmask('255.255.255.0')).to.be.true
-    expect(netmask('255.255.255.128')).to.be.true
-    expect(netmask('255.255.255.255')).to.be.true
+    expect(netmask('0.0.0.0')).to.be.equal(true)
+    expect(netmask('255.255.255.0')).to.be.equal(true)
+    expect(netmask('255.255.255.128')).to.be.equal(true)
+    expect(netmask('255.255.255.255')).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/port-number-test.js
+++ b/tests/validator/custom-formats/port-number-test.js
@@ -4,56 +4,56 @@ const portNumber = require('../../../lib/validator/custom-formats/port-number')
 
 describe('validator/custom-formats/port-number', () => {
   it('returns false when value is undefined', () => {
-    expect(portNumber(undefined)).to.be.false
+    expect(portNumber(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(portNumber(null)).to.be.false
+    expect(portNumber(null)).to.be.equal(false)
   })
 
   it('returns false when value is a string', () => {
-    expect(portNumber('test')).to.be.false
+    expect(portNumber('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(portNumber({})).to.be.false
+    expect(portNumber({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(portNumber([])).to.be.false
+    expect(portNumber([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(portNumber(0.5)).to.be.false
+    expect(portNumber(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(portNumber(NaN)).to.be.false
+    expect(portNumber(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(portNumber(Infinity)).to.be.false
+    expect(portNumber(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value < 0', () => {
-    expect(portNumber(-1)).to.be.false
-    expect(portNumber('-1')).to.be.false
+    expect(portNumber(-1)).to.be.equal(false)
+    expect(portNumber('-1')).to.be.equal(false)
   })
 
   it('returns false when value = 0', () => {
-    expect(portNumber(0)).to.be.false
-    expect(portNumber('0')).to.be.false
+    expect(portNumber(0)).to.be.equal(false)
+    expect(portNumber('0')).to.be.equal(false)
   })
 
   it('returns true when 1 <= value <= 65535', () => {
-    expect(portNumber(1)).to.be.true
-    expect(portNumber('1')).to.be.true
-    expect(portNumber(65535)).to.be.true
-    expect(portNumber('65535')).to.be.true
+    expect(portNumber(1)).to.be.equal(true)
+    expect(portNumber('1')).to.be.equal(true)
+    expect(portNumber(65535)).to.be.equal(true)
+    expect(portNumber('65535')).to.be.equal(true)
   })
 
   it('returns false when value > 65535', () => {
-    expect(portNumber(65536)).to.be.false
-    expect(portNumber('65536')).to.be.false
+    expect(portNumber(65536)).to.be.equal(false)
+    expect(portNumber('65536')).to.be.equal(false)
   })
 })

--- a/tests/validator/custom-formats/time-test.js
+++ b/tests/validator/custom-formats/time-test.js
@@ -4,240 +4,240 @@ const time = require('../../../lib/validator/custom-formats/time')
 
 describe('validator/custom-formats/time', () => {
   it('returns false when value is undefined', () => {
-    expect(time(undefined)).to.be.false
+    expect(time(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(time(null)).to.be.false
+    expect(time(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(time({})).to.be.false
+    expect(time({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(time([])).to.be.false
+    expect(time([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(time(0.5)).to.be.false
+    expect(time(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(time(NaN)).to.be.false
+    expect(time(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(time(Infinity)).to.be.false
+    expect(time(Infinity)).to.be.equal(false)
   })
 
   it('returns true when value is format hh:mm:ss', () => {
-    expect(time('04:01:05')).to.be.true
+    expect(time('04:01:05')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:mm', () => {
-    expect(time('04:01')).to.be.true
+    expect(time('04:01')).to.be.equal(true)
   })
 
   it('returns true when value is format hh', () => {
-    expect(time('04')).to.be.true
+    expect(time('04')).to.be.equal(true)
   })
 
   it('returns true when value is format h:mm:ss', () => {
-    expect(time('4:01:05')).to.be.true
+    expect(time('4:01:05')).to.be.equal(true)
   })
 
   it('returns true when value is format h:mm', () => {
-    expect(time('4:01')).to.be.true
+    expect(time('4:01')).to.be.equal(true)
   })
 
   it('returns true when value is format h', () => {
-    expect(time('4')).to.be.true
+    expect(time('4')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:m:ss', () => {
-    expect(time('04:1:05')).to.be.true
+    expect(time('04:1:05')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:m', () => {
-    expect(time('04:1')).to.be.true
+    expect(time('04:1')).to.be.equal(true)
   })
 
   it('returns true when value is format h:m:ss', () => {
-    expect(time('4:1:05')).to.be.true
+    expect(time('4:1:05')).to.be.equal(true)
   })
 
   it('returns true when value is format h:m', () => {
-    expect(time('4:1')).to.be.true
+    expect(time('4:1')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:mm:s', () => {
-    expect(time('04:01:5')).to.be.true
+    expect(time('04:01:5')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:m:s', () => {
-    expect(time('04:1:5')).to.be.true
+    expect(time('04:1:5')).to.be.equal(true)
   })
 
   it('returns true when value is format h:mm:s', () => {
-    expect(time('4:01:5')).to.be.true
+    expect(time('4:01:5')).to.be.equal(true)
   })
 
   it('returns true when value is format h:m:s', () => {
-    expect(time('4:1:5')).to.be.true
+    expect(time('4:1:5')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:mm:ss a', () => {
-    expect(time('04:01:05 am')).to.be.true
-    expect(time('04:01:05 AM')).to.be.true
-    expect(time('04:01:05 a.m.')).to.be.true
-    expect(time('04:01:05 A.M.')).to.be.true
-    expect(time('04:01:05 pm')).to.be.true
-    expect(time('04:01:05 PM')).to.be.true
-    expect(time('04:01:05 p.m.')).to.be.true
-    expect(time('04:01:05 P.M.')).to.be.true
+    expect(time('04:01:05 am')).to.be.equal(true)
+    expect(time('04:01:05 AM')).to.be.equal(true)
+    expect(time('04:01:05 a.m.')).to.be.equal(true)
+    expect(time('04:01:05 A.M.')).to.be.equal(true)
+    expect(time('04:01:05 pm')).to.be.equal(true)
+    expect(time('04:01:05 PM')).to.be.equal(true)
+    expect(time('04:01:05 p.m.')).to.be.equal(true)
+    expect(time('04:01:05 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:mm a', () => {
-    expect(time('04:01 am')).to.be.true
-    expect(time('04:01 AM')).to.be.true
-    expect(time('04:01 a.m.')).to.be.true
-    expect(time('04:01 A.M.')).to.be.true
-    expect(time('04:01 pm')).to.be.true
-    expect(time('04:01 PM')).to.be.true
-    expect(time('04:01 p.m.')).to.be.true
-    expect(time('04:01 P.M.')).to.be.true
+    expect(time('04:01 am')).to.be.equal(true)
+    expect(time('04:01 AM')).to.be.equal(true)
+    expect(time('04:01 a.m.')).to.be.equal(true)
+    expect(time('04:01 A.M.')).to.be.equal(true)
+    expect(time('04:01 pm')).to.be.equal(true)
+    expect(time('04:01 PM')).to.be.equal(true)
+    expect(time('04:01 p.m.')).to.be.equal(true)
+    expect(time('04:01 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format hh a', () => {
-    expect(time('04 am')).to.be.true
-    expect(time('04 AM')).to.be.true
-    expect(time('04 a.m.')).to.be.true
-    expect(time('04 A.M.')).to.be.true
-    expect(time('04 pm')).to.be.true
-    expect(time('04 PM')).to.be.true
-    expect(time('04 p.m.')).to.be.true
-    expect(time('04 P.M.')).to.be.true
+    expect(time('04 am')).to.be.equal(true)
+    expect(time('04 AM')).to.be.equal(true)
+    expect(time('04 a.m.')).to.be.equal(true)
+    expect(time('04 A.M.')).to.be.equal(true)
+    expect(time('04 pm')).to.be.equal(true)
+    expect(time('04 PM')).to.be.equal(true)
+    expect(time('04 p.m.')).to.be.equal(true)
+    expect(time('04 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format h:mm:ss a', () => {
-    expect(time('4:01:05 am')).to.be.true
-    expect(time('4:01:05 AM')).to.be.true
-    expect(time('4:01:05 a.m.')).to.be.true
-    expect(time('4:01:05 A.M.')).to.be.true
-    expect(time('4:01:05 pm')).to.be.true
-    expect(time('4:01:05 PM')).to.be.true
-    expect(time('4:01:05 p.m.')).to.be.true
-    expect(time('4:01:05 P.M.')).to.be.true
+    expect(time('4:01:05 am')).to.be.equal(true)
+    expect(time('4:01:05 AM')).to.be.equal(true)
+    expect(time('4:01:05 a.m.')).to.be.equal(true)
+    expect(time('4:01:05 A.M.')).to.be.equal(true)
+    expect(time('4:01:05 pm')).to.be.equal(true)
+    expect(time('4:01:05 PM')).to.be.equal(true)
+    expect(time('4:01:05 p.m.')).to.be.equal(true)
+    expect(time('4:01:05 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format h:mm a', () => {
-    expect(time('4:01 am')).to.be.true
-    expect(time('4:01 AM')).to.be.true
-    expect(time('4:01 a.m.')).to.be.true
-    expect(time('4:01 A.M.')).to.be.true
-    expect(time('4:01 pm')).to.be.true
-    expect(time('4:01 PM')).to.be.true
-    expect(time('4:01 p.m.')).to.be.true
-    expect(time('4:01 P.M.')).to.be.true
+    expect(time('4:01 am')).to.be.equal(true)
+    expect(time('4:01 AM')).to.be.equal(true)
+    expect(time('4:01 a.m.')).to.be.equal(true)
+    expect(time('4:01 A.M.')).to.be.equal(true)
+    expect(time('4:01 pm')).to.be.equal(true)
+    expect(time('4:01 PM')).to.be.equal(true)
+    expect(time('4:01 p.m.')).to.be.equal(true)
+    expect(time('4:01 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format h a', () => {
-    expect(time('4 am')).to.be.true
-    expect(time('4 AM')).to.be.true
-    expect(time('4 a.m.')).to.be.true
-    expect(time('4 A.M.')).to.be.true
-    expect(time('4 pm')).to.be.true
-    expect(time('4 PM')).to.be.true
-    expect(time('4 p.m.')).to.be.true
-    expect(time('4 P.M.')).to.be.true
+    expect(time('4 am')).to.be.equal(true)
+    expect(time('4 AM')).to.be.equal(true)
+    expect(time('4 a.m.')).to.be.equal(true)
+    expect(time('4 A.M.')).to.be.equal(true)
+    expect(time('4 pm')).to.be.equal(true)
+    expect(time('4 PM')).to.be.equal(true)
+    expect(time('4 p.m.')).to.be.equal(true)
+    expect(time('4 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:m:ss a', () => {
-    expect(time('04:1:05 am')).to.be.true
-    expect(time('04:1:05 AM')).to.be.true
-    expect(time('04:1:05 a.m.')).to.be.true
-    expect(time('04:1:05 A.M.')).to.be.true
-    expect(time('04:1:05 pm')).to.be.true
-    expect(time('04:1:05 PM')).to.be.true
-    expect(time('04:1:05 p.m.')).to.be.true
-    expect(time('04:1:05 P.M.')).to.be.true
+    expect(time('04:1:05 am')).to.be.equal(true)
+    expect(time('04:1:05 AM')).to.be.equal(true)
+    expect(time('04:1:05 a.m.')).to.be.equal(true)
+    expect(time('04:1:05 A.M.')).to.be.equal(true)
+    expect(time('04:1:05 pm')).to.be.equal(true)
+    expect(time('04:1:05 PM')).to.be.equal(true)
+    expect(time('04:1:05 p.m.')).to.be.equal(true)
+    expect(time('04:1:05 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:m a', () => {
-    expect(time('04:1 am')).to.be.true
-    expect(time('04:1 AM')).to.be.true
-    expect(time('04:1 a.m.')).to.be.true
-    expect(time('04:1 A.M.')).to.be.true
-    expect(time('04:1 pm')).to.be.true
-    expect(time('04:1 PM')).to.be.true
-    expect(time('04:1 p.m.')).to.be.true
-    expect(time('04:1 P.M.')).to.be.true
+    expect(time('04:1 am')).to.be.equal(true)
+    expect(time('04:1 AM')).to.be.equal(true)
+    expect(time('04:1 a.m.')).to.be.equal(true)
+    expect(time('04:1 A.M.')).to.be.equal(true)
+    expect(time('04:1 pm')).to.be.equal(true)
+    expect(time('04:1 PM')).to.be.equal(true)
+    expect(time('04:1 p.m.')).to.be.equal(true)
+    expect(time('04:1 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format h:m:ss a', () => {
-    expect(time('4:1:05 am')).to.be.true
-    expect(time('4:1:05 AM')).to.be.true
-    expect(time('4:1:05 a.m.')).to.be.true
-    expect(time('4:1:05 A.M.')).to.be.true
-    expect(time('4:1:05 pm')).to.be.true
-    expect(time('4:1:05 PM')).to.be.true
-    expect(time('4:1:05 p.m.')).to.be.true
-    expect(time('4:1:05 P.M.')).to.be.true
+    expect(time('4:1:05 am')).to.be.equal(true)
+    expect(time('4:1:05 AM')).to.be.equal(true)
+    expect(time('4:1:05 a.m.')).to.be.equal(true)
+    expect(time('4:1:05 A.M.')).to.be.equal(true)
+    expect(time('4:1:05 pm')).to.be.equal(true)
+    expect(time('4:1:05 PM')).to.be.equal(true)
+    expect(time('4:1:05 p.m.')).to.be.equal(true)
+    expect(time('4:1:05 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format h:m a', () => {
-    expect(time('4:1 am')).to.be.true
-    expect(time('4:1 AM')).to.be.true
-    expect(time('4:1 a.m.')).to.be.true
-    expect(time('4:1 A.M.')).to.be.true
-    expect(time('4:1 pm')).to.be.true
-    expect(time('4:1 PM')).to.be.true
-    expect(time('4:1 p.m.')).to.be.true
-    expect(time('4:1 P.M.')).to.be.true
+    expect(time('4:1 am')).to.be.equal(true)
+    expect(time('4:1 AM')).to.be.equal(true)
+    expect(time('4:1 a.m.')).to.be.equal(true)
+    expect(time('4:1 A.M.')).to.be.equal(true)
+    expect(time('4:1 pm')).to.be.equal(true)
+    expect(time('4:1 PM')).to.be.equal(true)
+    expect(time('4:1 p.m.')).to.be.equal(true)
+    expect(time('4:1 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:mm:s a', () => {
-    expect(time('04:01:5 am')).to.be.true
-    expect(time('04:01:5 AM')).to.be.true
-    expect(time('04:01:5 a.m.')).to.be.true
-    expect(time('04:01:5 A.M.')).to.be.true
-    expect(time('04:01:5 pm')).to.be.true
-    expect(time('04:01:5 PM')).to.be.true
-    expect(time('04:01:5 p.m.')).to.be.true
-    expect(time('04:01:5 P.M.')).to.be.true
+    expect(time('04:01:5 am')).to.be.equal(true)
+    expect(time('04:01:5 AM')).to.be.equal(true)
+    expect(time('04:01:5 a.m.')).to.be.equal(true)
+    expect(time('04:01:5 A.M.')).to.be.equal(true)
+    expect(time('04:01:5 pm')).to.be.equal(true)
+    expect(time('04:01:5 PM')).to.be.equal(true)
+    expect(time('04:01:5 p.m.')).to.be.equal(true)
+    expect(time('04:01:5 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format hh:m:s a', () => {
-    expect(time('04:1:5 am')).to.be.true
-    expect(time('04:1:5 AM')).to.be.true
-    expect(time('04:1:5 a.m.')).to.be.true
-    expect(time('04:1:5 A.M.')).to.be.true
-    expect(time('04:1:5 pm')).to.be.true
-    expect(time('04:1:5 PM')).to.be.true
-    expect(time('04:1:5 p.m.')).to.be.true
-    expect(time('04:1:5 P.M.')).to.be.true
+    expect(time('04:1:5 am')).to.be.equal(true)
+    expect(time('04:1:5 AM')).to.be.equal(true)
+    expect(time('04:1:5 a.m.')).to.be.equal(true)
+    expect(time('04:1:5 A.M.')).to.be.equal(true)
+    expect(time('04:1:5 pm')).to.be.equal(true)
+    expect(time('04:1:5 PM')).to.be.equal(true)
+    expect(time('04:1:5 p.m.')).to.be.equal(true)
+    expect(time('04:1:5 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format h:mm:s a', () => {
-    expect(time('4:01:5 am')).to.be.true
-    expect(time('4:01:5 AM')).to.be.true
-    expect(time('4:01:5 a.m.')).to.be.true
-    expect(time('4:01:5 A.M.')).to.be.true
-    expect(time('4:01:5 pm')).to.be.true
-    expect(time('4:01:5 PM')).to.be.true
-    expect(time('4:01:5 p.m.')).to.be.true
-    expect(time('4:01:5 P.M.')).to.be.true
+    expect(time('4:01:5 am')).to.be.equal(true)
+    expect(time('4:01:5 AM')).to.be.equal(true)
+    expect(time('4:01:5 a.m.')).to.be.equal(true)
+    expect(time('4:01:5 A.M.')).to.be.equal(true)
+    expect(time('4:01:5 pm')).to.be.equal(true)
+    expect(time('4:01:5 PM')).to.be.equal(true)
+    expect(time('4:01:5 p.m.')).to.be.equal(true)
+    expect(time('4:01:5 P.M.')).to.be.equal(true)
   })
 
   it('returns true when value is format h:m:s a', () => {
-    expect(time('4:1:5 am')).to.be.true
-    expect(time('4:1:5 AM')).to.be.true
-    expect(time('4:1:5 a.m.')).to.be.true
-    expect(time('4:1:5 A.M.')).to.be.true
-    expect(time('4:1:5 pm')).to.be.true
-    expect(time('4:1:5 PM')).to.be.true
-    expect(time('4:1:5 p.m.')).to.be.true
-    expect(time('4:1:5 P.M.')).to.be.true
+    expect(time('4:1:5 am')).to.be.equal(true)
+    expect(time('4:1:5 AM')).to.be.equal(true)
+    expect(time('4:1:5 a.m.')).to.be.equal(true)
+    expect(time('4:1:5 A.M.')).to.be.equal(true)
+    expect(time('4:1:5 pm')).to.be.equal(true)
+    expect(time('4:1:5 PM')).to.be.equal(true)
+    expect(time('4:1:5 p.m.')).to.be.equal(true)
+    expect(time('4:1:5 P.M.')).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/uint16-test.js
+++ b/tests/validator/custom-formats/uint16-test.js
@@ -4,51 +4,51 @@ const uint16 = require('../../../lib/validator/custom-formats/uint16')
 
 describe('validator/custom-formats/uint16', () => {
   it('returns false when value is undefined', () => {
-    expect(uint16(undefined)).to.be.false
+    expect(uint16(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(uint16(null)).to.be.false
+    expect(uint16(null)).to.be.equal(false)
   })
 
   it('returns false when value is a string', () => {
-    expect(uint16('test')).to.be.false
+    expect(uint16('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(uint16({})).to.be.false
+    expect(uint16({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(uint16([])).to.be.false
+    expect(uint16([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(uint16(0.5)).to.be.false
+    expect(uint16(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(uint16(NaN)).to.be.false
+    expect(uint16(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(uint16(Infinity)).to.be.false
+    expect(uint16(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value = -1', () => {
-    expect(uint16(-1)).to.be.false
-    expect(uint16('-1')).to.be.false
+    expect(uint16(-1)).to.be.equal(false)
+    expect(uint16('-1')).to.be.equal(false)
   })
 
   it('returns true when 0 <= value <= 65535', () => {
-    expect(uint16(0)).to.be.true
-    expect(uint16('0')).to.be.true
-    expect(uint16(65535)).to.be.true
-    expect(uint16('65535')).to.be.true
+    expect(uint16(0)).to.be.equal(true)
+    expect(uint16('0')).to.be.equal(true)
+    expect(uint16(65535)).to.be.equal(true)
+    expect(uint16('65535')).to.be.equal(true)
   })
 
   it('returns false when value = 65536', () => {
-    expect(uint16(65536)).to.be.false
-    expect(uint16('65536')).to.be.false
+    expect(uint16(65536)).to.be.equal(false)
+    expect(uint16('65536')).to.be.equal(false)
   })
 })

--- a/tests/validator/custom-formats/uint8-test.js
+++ b/tests/validator/custom-formats/uint8-test.js
@@ -4,51 +4,51 @@ const uint8 = require('../../../lib/validator/custom-formats/uint8')
 
 describe('validator/custom-formats/uint8', () => {
   it('returns false when value is undefined', () => {
-    expect(uint8(undefined)).to.be.false
+    expect(uint8(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(uint8(null)).to.be.false
+    expect(uint8(null)).to.be.equal(false)
   })
 
   it('returns false when value is a string', () => {
-    expect(uint8('test')).to.be.false
+    expect(uint8('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(uint8({})).to.be.false
+    expect(uint8({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(uint8([])).to.be.false
+    expect(uint8([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(uint8(0.5)).to.be.false
+    expect(uint8(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(uint8(NaN)).to.be.false
+    expect(uint8(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(uint8(Infinity)).to.be.false
+    expect(uint8(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value = -1', () => {
-    expect(uint8(-1)).to.be.false
-    expect(uint8('-1')).to.be.false
+    expect(uint8(-1)).to.be.equal(false)
+    expect(uint8('-1')).to.be.equal(false)
   })
 
   it('returns true when 0 <= value <= 255', () => {
-    expect(uint8(0)).to.be.true
-    expect(uint8('0')).to.be.true
-    expect(uint8(255)).to.be.true
-    expect(uint8('255')).to.be.true
+    expect(uint8(0)).to.be.equal(true)
+    expect(uint8('0')).to.be.equal(true)
+    expect(uint8(255)).to.be.equal(true)
+    expect(uint8('255')).to.be.equal(true)
   })
 
   it('returns false when value > 255', () => {
-    expect(uint8(256)).to.be.false
-    expect(uint8('256')).to.be.false
+    expect(uint8(256)).to.be.equal(false)
+    expect(uint8('256')).to.be.equal(false)
   })
 })

--- a/tests/validator/custom-formats/unit32-test.js
+++ b/tests/validator/custom-formats/unit32-test.js
@@ -4,55 +4,55 @@ const uint32 = require('../../../lib/validator/custom-formats/uint32')
 
 describe('validator/custom-formats/unit32', () => {
   it('returns false when value is undefined', () => {
-    expect(uint32(undefined)).to.be.false
+    expect(uint32(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(uint32(null)).to.be.false
+    expect(uint32(null)).to.be.equal(false)
   })
 
   it('returns false when value is a string', () => {
-    expect(uint32('test')).to.be.false
+    expect(uint32('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(uint32({})).to.be.false
+    expect(uint32({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(uint32([])).to.be.false
+    expect(uint32([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(uint32(0.5)).to.be.false
+    expect(uint32(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(uint32(NaN)).to.be.false
+    expect(uint32(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(uint32(Infinity)).to.be.false
+    expect(uint32(Infinity)).to.be.equal(false)
   })
 
   it('returns true when value is an integer', () => {
-    expect(uint32(0)).to.be.true
+    expect(uint32(0)).to.be.equal(true)
   })
 
   it('returns false when value < 0', () => {
-    expect(uint32(-1)).to.be.false
-    expect(uint32('-1')).to.be.false
+    expect(uint32(-1)).to.be.equal(false)
+    expect(uint32('-1')).to.be.equal(false)
   })
 
   it('returns true when 0 <= value <= 4294967295', () => {
-    expect(uint32(0)).to.be.true
-    expect(uint32('0')).to.be.true
-    expect(uint32(4294967295)).to.be.true
-    expect(uint32('4294967295')).to.be.true
+    expect(uint32(0)).to.be.equal(true)
+    expect(uint32('0')).to.be.equal(true)
+    expect(uint32(4294967295)).to.be.equal(true)
+    expect(uint32('4294967295')).to.be.equal(true)
   })
 
   it('returns false when value > 4294967295', () => {
-    expect(uint32(4294967296)).to.be.false
-    expect(uint32('4294967296')).to.be.false
+    expect(uint32(4294967296)).to.be.equal(false)
+    expect(uint32('4294967296')).to.be.equal(false)
   })
 })

--- a/tests/validator/custom-formats/url-test.js
+++ b/tests/validator/custom-formats/url-test.js
@@ -4,35 +4,35 @@ const url = require('../../../lib/validator/custom-formats/url')
 
 describe('validator/custom-formats/url', () => {
   it('returns false when value is undefined', () => {
-    expect(url(undefined)).to.be.false
+    expect(url(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(url(null)).to.be.false
+    expect(url(null)).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(url({})).to.be.false
+    expect(url({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(url([])).to.be.false
+    expect(url([])).to.be.equal(false)
   })
 
   it('returns false when value is an integer', () => {
-    expect(url(1)).to.be.false
+    expect(url(1)).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(url(0.5)).to.be.false
+    expect(url(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(url(NaN)).to.be.false
+    expect(url(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(url(Infinity)).to.be.false
+    expect(url(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value is not valid', () => {
@@ -41,7 +41,7 @@ describe('validator/custom-formats/url', () => {
       '1'
     ]
       .forEach((value) => {
-        expect(url(value)).to.be.false
+        expect(url(value)).to.be.equal(false)
       })
   })
 
@@ -53,7 +53,7 @@ describe('validator/custom-formats/url', () => {
       'https://www.subdomain.domain.com'
     ]
       .forEach((value) => {
-        expect(url(value)).to.be.true
+        expect(url(value)).to.be.equal(true)
       })
   })
 })

--- a/tests/validator/custom-formats/vlan-id-test.js
+++ b/tests/validator/custom-formats/vlan-id-test.js
@@ -4,56 +4,56 @@ const vlanId = require('../../../lib/validator/custom-formats/vlan-id')
 
 describe('validator/custom-formats/vlan-id', () => {
   it('returns false when value is undefined', () => {
-    expect(vlanId(undefined)).to.be.false
+    expect(vlanId(undefined)).to.be.equal(false)
   })
 
   it('returns false when value is null', () => {
-    expect(vlanId(null)).to.be.false
+    expect(vlanId(null)).to.be.equal(false)
   })
 
   it('returns false when value is a string', () => {
-    expect(vlanId('test')).to.be.false
+    expect(vlanId('test')).to.be.equal(false)
   })
 
   it('returns false when value is an object', () => {
-    expect(vlanId({})).to.be.false
+    expect(vlanId({})).to.be.equal(false)
   })
 
   it('returns false when value is an array', () => {
-    expect(vlanId([])).to.be.false
+    expect(vlanId([])).to.be.equal(false)
   })
 
   it('returns false when value is a float', () => {
-    expect(vlanId(0.5)).to.be.false
+    expect(vlanId(0.5)).to.be.equal(false)
   })
 
   it('returns false when value is NaN', () => {
-    expect(vlanId(NaN)).to.be.false
+    expect(vlanId(NaN)).to.be.equal(false)
   })
 
   it('returns false when value is Infinity', () => {
-    expect(vlanId(Infinity)).to.be.false
+    expect(vlanId(Infinity)).to.be.equal(false)
   })
 
   it('returns false when value < 0', () => {
-    expect(vlanId(-1)).to.be.false
-    expect(vlanId('-1')).to.be.false
+    expect(vlanId(-1)).to.be.equal(false)
+    expect(vlanId('-1')).to.be.equal(false)
   })
 
   it('returns false when value = 0', () => {
-    expect(vlanId(0)).to.be.false
-    expect(vlanId('0')).to.be.false
+    expect(vlanId(0)).to.be.equal(false)
+    expect(vlanId('0')).to.be.equal(false)
   })
 
   it('returns true when 1 <= value <= 4094', () => {
-    expect(vlanId(1)).to.be.true
-    expect(vlanId('1')).to.be.true
-    expect(vlanId(4094)).to.be.true
-    expect(vlanId('4094')).to.be.true
+    expect(vlanId(1)).to.be.equal(true)
+    expect(vlanId('1')).to.be.equal(true)
+    expect(vlanId(4094)).to.be.equal(true)
+    expect(vlanId('4094')).to.be.equal(true)
   })
 
   it('returns false when value > 4094', () => {
-    expect(vlanId(4095)).to.be.false
-    expect(vlanId('4095')).to.be.false
+    expect(vlanId(4095)).to.be.equal(false)
+    expect(vlanId('4095')).to.be.equal(false)
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Replaced** instances of `to.be.true` and `to.be.false` with `to.be.equal(true)` and `to.be.equal(false)` because mocha/chai won't error if you have a typo in the property that's not a function (i.e. `expect(false).to.be.fooBarBaz` passes without issue, even though there's no such check as `fooBarBaz`. 
