### PR TITLE
Allow first array item to be set when array doesn't exist

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -80,8 +80,20 @@ export const actionReducers = {
       newValue = immutable(recursiveClean(value))
     } else {
       newValue = immutable(state.value)
+      const segments = bunsenId.split('.')
+      const lastSegment = segments.pop()
+      const isArrayItem = /^\d+$/.test(lastSegment)
 
-      if (_.includes([null, ''], value) || (Array.isArray(value) && value.length === 0)) {
+      if (isArrayItem) {
+        const parentPath = segments.join('.')
+        const parentObject = _.get(newValue, parentPath)
+
+        if (parentObject && _.includes([null, ''], value)) {
+          newValue = unset(newValue, bunsenId)
+        } else {
+          newValue = set(newValue, bunsenId, value)
+        }
+      } else if (_.includes([null, ''], value) || (Array.isArray(value) && value.length === 0)) {
         newValue = unset(newValue, bunsenId)
       } else {
         newValue = set(newValue, bunsenId, value)

--- a/tests/reducer/change-value-test.js
+++ b/tests/reducer/change-value-test.js
@@ -1,0 +1,187 @@
+var expect = require('chai').expect
+var actions = require('../../lib/actions')
+var reducerExports = require('../../lib/reducer')
+var reducer = reducerExports.reducer
+
+function getInitialStateWithValue (value) {
+  return {
+    errors: {},
+    validationResult: {warnings: [], errors: []},
+    value,
+    baseModel: {}
+  }
+}
+
+function getStateWithValue (value) {
+  return {
+    errors: {},
+    model: {},
+    validationResult: {warnings: [], errors: []},
+    value: value,
+    baseModel: {}
+  }
+}
+
+const tests = [
+  {
+    change: {
+      bunsenId: null,
+      value: {}
+    },
+    description: 'sets root object',
+    initialValue: null,
+    newValue: {}
+  }
+]
+
+;[
+  {type: 'boolean', initialValue: false, newValue: true},
+  {type: 'integer', initialValue: 2, newValue: 1},
+  {type: 'number', initialValue: 3.4, newValue: 1.5},
+  {type: 'string', initialValue: 'baz', newValue: 'bar'}
+]
+  .forEach((test) => {
+    tests.push(
+      {
+        change: {
+          bunsenId: 'foo',
+          value: test.newValue
+        },
+        description: `sets ${test.type} property`,
+        initialValue: null,
+        newValue: {
+          foo: test.newValue
+        }
+      },
+      {
+        change: {
+          bunsenId: 'foo',
+          value: test.newValue
+        },
+        description: `updates ${test.type} property`,
+        initialValue: {
+          foo: test.initialValue
+        },
+        newValue: {
+          foo: test.newValue
+        }
+      },
+      {
+        change: {
+          bunsenId: 'foo',
+          value: null
+        },
+        description: `unsets ${test.type} property`,
+        initialValue: {
+          foo: test.initialValue
+        },
+        newValue: {}
+      },
+      {
+        change: {
+          bunsenId: 'foo.0',
+          value: test.newValue
+        },
+        description: `sets ${test.type} array item in non-present array`,
+        initialValue: null,
+        newValue: {
+          foo: [test.newValue]
+        }
+      },
+      {
+        change: {
+          bunsenId: 'foo.0',
+          value: test.newValue
+        },
+        description: `sets ${test.type} array item in empty array`,
+        initialValue: {
+          foo: []
+        },
+        newValue: {
+          foo: [test.newValue]
+        }
+      },
+      {
+        change: {
+          bunsenId: 'foo.0',
+          value: test.newValue
+        },
+        description: `updates ${test.type} array item in array`,
+        initialValue: {
+          foo: [test.initialValue]
+        },
+        newValue: {
+          foo: [test.newValue]
+        }
+      },
+      {
+        change: {
+          bunsenId: 'foo.1',
+          value: test.newValue
+        },
+        description: `adds ${test.type} array item to array`,
+        initialValue: {
+          foo: [test.initialValue]
+        },
+        newValue: {
+          foo: [test.initialValue, test.newValue]
+        }
+      },
+      {
+        change: {
+          bunsenId: 'foo.0',
+          value: test.newValue
+        },
+        description: `updates ${test.type} array item at beginning of array`,
+        initialValue: {
+          foo: [test.initialValue, test.initialValue, test.initialValue]
+        },
+        newValue: {
+          foo: [test.newValue, test.initialValue, test.initialValue]
+        }
+      },
+      {
+        change: {
+          bunsenId: 'foo.2',
+          value: test.newValue
+        },
+        description: `updates ${test.type} array item at end of array`,
+        initialValue: {
+          foo: [test.initialValue, test.initialValue, test.initialValue]
+        },
+        newValue: {
+          foo: [test.initialValue, test.initialValue, test.newValue]
+        }
+      },
+      {
+        change: {
+          bunsenId: 'foo.1',
+          value: test.newValue
+        },
+        description: `updates ${test.type} array item in middle of array`,
+        initialValue: {
+          foo: [test.initialValue, test.initialValue, test.initialValue]
+        },
+        newValue: {
+          foo: [test.initialValue, test.newValue, test.initialValue]
+        }
+      }
+    )
+  })
+
+describe('change value reducer', function () {
+  tests.forEach((test) => {
+    it(test.description, function () {
+      const expected = getStateWithValue(test.newValue)
+      const initialState = getInitialStateWithValue(test.initialValue)
+
+      const actual = reducer(initialState, {
+        bunsenId: test.change.bunsenId,
+        type: actions.CHANGE_VALUE,
+        value: test.change.value
+      })
+
+      expect(actual).to.eql(expected)
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** an issue where the first item in an array couldn't be set if the array didn't already exist.
