### PR TITLE
Preserve label when converting v1 view to v2

### DIFF
--- a/src/conversion/view-v1-to-v2.js
+++ b/src/conversion/view-v1-to-v2.js
@@ -203,10 +203,6 @@ export function generateCellDefinitions (containers) {
 export default function viewV1ToV2 (v1View) {
   const {type} = v1View
 
-  if (v1View.rootContainers.length === 1) {
-    delete v1View.rootContainers[0].label
-  }
-
   const cells = generateCells(v1View.rootContainers)
 
   const cellDefinitions = generateCellDefinitions(v1View.containers)

--- a/tests/fixtures/array-view.js
+++ b/tests/fixtures/array-view.js
@@ -3,7 +3,8 @@ module.exports = {
   type: 'form',
   cells: [
     {
-      extends: 'main'
+      extends: 'main',
+      label: 'Main'
     }
   ],
   cellDefinitions: {

--- a/tests/fixtures/class-name-view.js
+++ b/tests/fixtures/class-name-view.js
@@ -34,7 +34,8 @@ module.exports = {
   },
   cells: [
     {
-      extends: 'main'
+      extends: 'main',
+      label: 'Main'
     }
   ],
   type: 'form',

--- a/tests/fixtures/collapsible-view.js
+++ b/tests/fixtures/collapsible-view.js
@@ -27,7 +27,8 @@ module.exports = {
   },
   cells: [
     {
-      extends: 'main'
+      extends: 'main',
+      label: 'Main'
     }
   ],
   type: 'form',

--- a/tests/fixtures/simple-view.js
+++ b/tests/fixtures/simple-view.js
@@ -3,7 +3,8 @@ module.exports = {
   type: 'form',
   cells: [
     {
-      extends: 'main'
+      extends: 'main',
+      label: 'Main'
     }
   ],
   cellDefinitions: {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** bug where `label` was being dropped from `rootContainer` from v1 view being converted to v2.
