### PR TITLE
Fix bug in evaluate

### DIFF
--- a/src/evaluate-conditions.js
+++ b/src/evaluate-conditions.js
@@ -90,6 +90,10 @@ export default function evaluate (model, value, getPreviousValue) {
 
   const getValue = pathFinder(value, getPreviousValue)
 
+  if (!model.properties) {
+    return retModel
+  }
+
   retModel.properties = _.clone(model.properties)
   _.forEach(retModel.properties, function (subSchema, propName) {
     retModel.properties[propName] = evaluate(subSchema, _.get(value, propName), pathFinder(value, getValue))

--- a/tests/evaluate-conditions-test.js
+++ b/tests/evaluate-conditions-test.js
@@ -26,7 +26,7 @@ function dereferenceAndEval (model, value) {
   return evaluate(schema, value)
 }
 
-describe('evaluate-coniditions', () => {
+describe('evaluate-conditions', () => {
   var model, newModel, value, expected
 
   // FIXME: in the next major release, we want this to behave differently, the 'if' condition should not invert
@@ -49,6 +49,14 @@ describe('evaluate-coniditions', () => {
         }
       }
     })
+  })
+
+  it('does not add additional undefined properties', function () {
+    model = {
+      type: 'object'
+    }
+    var newModel = dereferenceAndEval(model, {})
+    expect('properties' in newModel).to.equal(false)
   })
 
   describe('when nothing passed in', () => {
@@ -238,7 +246,7 @@ describe('evaluate-coniditions', () => {
         newModel = dereferenceAndEval(model, value)
       })
 
-      it('evalutates to anyOf the possible items', () => {
+      it('evaluates to anyOf the possible items', () => {
         expect(newModel).to.eql({
           type: 'object',
           properties: {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Fixed `properties: undefined` bug when models were `evaluated`
