### PR TITLE
Add support for square bracket array index referencing in bunsen views

### DIFF
--- a/src/conversion/normalize-view.js
+++ b/src/conversion/normalize-view.js
@@ -1,0 +1,43 @@
+import _ from 'lodash'
+
+export function normalizeModelProperty (object) {
+  if (Array.isArray(object)) {
+    return object
+      .map((item) => {
+        return normalizeModelProperty(item)
+      })
+  }
+
+  if (!_.isPlainObject(object)) {
+    return object
+  }
+
+  Object.keys(object)
+    .forEach((key) => {
+      const isModelProperty = key === 'model' && _.isString(object[key])
+
+      if (!isModelProperty) {
+        object[key] = normalizeModelProperty(object[key])
+        return
+      }
+
+      // Convert foo[0].bar to foo.0.bar
+      object[key] = object[key].replace(/\[/g, '.').replace(/]/g, '')
+    })
+
+  return object
+}
+
+function normalizeView (bunsenView) {
+  if (bunsenView.cellDefinitions) {
+    normalizeModelProperty(bunsenView.cellDefinitions)
+  }
+
+  if (bunsenView.cells) {
+    normalizeModelProperty(bunsenView.cells)
+  }
+
+  return bunsenView
+}
+
+export default normalizeView

--- a/src/conversion/normalize-view.js
+++ b/src/conversion/normalize-view.js
@@ -1,5 +1,11 @@
 import _ from 'lodash'
 
+/**
+ * Ensure model property in bunsen view partial uses dot notation for
+ * referning array items by converting square brackets format to dot notation.
+ * @param {Object} object - bunsen view partial
+ * @returns {Object} normalized bunsen view partial
+ */
 export function normalizeModelProperty (object) {
   if (Array.isArray(object)) {
     return object
@@ -28,6 +34,11 @@ export function normalizeModelProperty (object) {
   return object
 }
 
+/**
+ * Normalize bunsen view to be more strict (ie. cleaning up model properties)
+ * @param {Object} bunsenView - bunsen view
+ * @returns {Object} normalized bunsen view
+ */
 function normalizeView (bunsenView) {
   if (bunsenView.cellDefinitions) {
     normalizeModelProperty(bunsenView.cellDefinitions)

--- a/tests/conversion/normalize-view-test.js
+++ b/tests/conversion/normalize-view-test.js
@@ -1,0 +1,84 @@
+var expect = require('chai').expect
+var normalizeView = require('../../lib/conversion/normalize-view').default
+
+describe('normalizeView()', function () {
+  it(' normalizes view as expected', function () {
+    const input = {
+      cellDefinitions: {
+        test: {
+          children: [
+            {model: 'foo[0]'},
+            {model: 'foo[0].bar'},
+            {model: 'alpha[0][1]'},
+            {model: 'alpha[0][1].bravo'}
+          ]
+        },
+        model: {
+          children: [
+            {model: 'foo[0]'},
+            {model: 'foo[0].bar'},
+            {model: 'alpha[0][1]'},
+            {model: 'alpha[0][1].bravo'}
+          ]
+        }
+      },
+      cells: [
+        {model: 'foo[0]'},
+        {model: 'foo[0].bar'},
+        {model: 'alpha[0][1]'},
+        {model: 'alpha[0][1].bravo'},
+        {
+          children: [
+            {model: 'foo[0]'},
+            {model: 'foo[0].bar'},
+            {model: 'alpha[0][1]'},
+            {model: 'alpha[0][1].bravo'}
+          ]
+        },
+        {extends: 'test'},
+        {extends: 'model'}
+      ],
+      type: 'form',
+      version: '2.0'
+    }
+
+    expect(normalizeView(input)).to.eql({
+      cellDefinitions: {
+        test: {
+          children: [
+            {model: 'foo.0'},
+            {model: 'foo.0.bar'},
+            {model: 'alpha.0.1'},
+            {model: 'alpha.0.1.bravo'}
+          ]
+        },
+        model: {
+          children: [
+            {model: 'foo.0'},
+            {model: 'foo.0.bar'},
+            {model: 'alpha.0.1'},
+            {model: 'alpha.0.1.bravo'}
+          ]
+        }
+      },
+      cells: [
+        {model: 'foo.0'},
+        {model: 'foo.0.bar'},
+        {model: 'alpha.0.1'},
+        {model: 'alpha.0.1.bravo'},
+        {
+          children: [
+            {model: 'foo.0'},
+            {model: 'foo.0.bar'},
+            {model: 'alpha.0.1'},
+            {model: 'alpha.0.1.bravo'}
+          ]
+        },
+        {extends: 'test'},
+        {extends: 'model'}
+      ],
+      type: 'form',
+      version: '2.0'
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** utility method to add support for square bracket array index referencing in bunsen views.
