### PR TITLE
Mac address validator

### DIFF
--- a/src/validator/custom-formats/index.js
+++ b/src/validator/custom-formats/index.js
@@ -10,6 +10,9 @@ import ipv4Address from './ipv4-address'
 import ipv4Interface from './ipv4-interface'
 import ipv4Prefix from './ipv4-prefix'
 import ipv6Address from './ipv6-address'
+import macAddress from './mac-address'
+import macInterface from './mac-interface'
+import macPrefix from './mac-prefix'
 import netmask from './netmask'
 import portNumber from './port-number'
 import time from './time'
@@ -33,6 +36,9 @@ export default {
   'ipv4-prefix': ipv4Prefix,
   'ipv6-address': ipv6Address,
   netmask,
+  'mac-address': macAddress,
+  'mac-interface': macInterface,
+  'mac-prefix': macPrefix,
   'port-number': portNumber,
   time,
   uint8,

--- a/src/validator/custom-formats/mac-address.js
+++ b/src/validator/custom-formats/mac-address.js
@@ -1,0 +1,9 @@
+import validator from 'validator'
+
+export default function (value) {
+  try {
+    return validator.isMACAddress(value)
+  } catch (err) {
+    return false
+  }
+}

--- a/src/validator/custom-formats/mac-interface.js
+++ b/src/validator/custom-formats/mac-interface.js
@@ -1,0 +1,31 @@
+import isMacAddress from './mac-address'
+import {isMacMaskValid, macAddressBits} from './utils'
+
+/**
+ * Validate value as an MAC address interface
+ * @param {Any} value - value to validate
+ * @returns {Boolean} whether or not value is valid
+ */
+export default function (value) {
+  if (!(typeof value === 'string' || value instanceof String)) {
+    return false
+  }
+
+  const [macAddress, mask] = value.split('/')
+
+  if (!isMacAddress(macAddress)) {
+    return false
+  }
+
+  if (!isMacMaskValid(mask)) {
+    return false
+  }
+
+  const bits = macAddressBits(macAddress)
+  const hostBits = bits.slice(parseInt(mask, 10))
+
+  return !(
+    /^0+$/.test(hostBits) ||
+    /^1+$/.test(hostBits)
+  )
+}

--- a/src/validator/custom-formats/mac-prefix.js
+++ b/src/validator/custom-formats/mac-prefix.js
@@ -1,0 +1,28 @@
+import isMacAddress from './mac-address'
+import {isMacMaskValid, macAddressBits} from './utils'
+
+/**
+ * Validate value as an MAC address prefix
+ * @param {Any} value - value to validate
+ * @returns {Boolean} whether or not value is valid
+ */
+export default function (value) {
+  if (!(typeof value === 'string' || value instanceof String)) {
+    return false
+  }
+
+  const [macAddress, mask] = value.split('/')
+
+  if (!isMacAddress(macAddress)) {
+    return false
+  }
+
+  if (!isMacMaskValid(mask)) {
+    return false
+  }
+
+  const bits = macAddressBits(macAddress)
+  const hostBits = bits.slice(parseInt(mask, 10))
+
+  return /^0+$/.test(hostBits)
+}

--- a/src/validator/custom-formats/utils.js
+++ b/src/validator/custom-formats/utils.js
@@ -1,5 +1,7 @@
 export const networkMaskMax = 32
 export const networkMaskMin = 0
+export const macMaskMax = 48
+export const macMaskMin = 0
 
 /**
  * Convert decimal value to binary representation
@@ -13,6 +15,15 @@ export function decimalToBinary (decimal) {
   const twosComplement = decimal >>> 0
   const binaryStr = twosComplement.toString(2)
   return PAD.substring(binaryStr.length) + binaryStr
+}
+
+/**
+ * Convert decimal value to binary representation
+ * @param {Number} hexString - decimal value to convert to binary
+ * @returns {String} string containing binary representation
+ */
+export function hexToBinary (hexString) {
+  return parseInt(hexString, 16).toString(2)
 }
 
 /**
@@ -30,6 +41,16 @@ export function networkMaskValid (value) {
 }
 
 /**
+ * Determine whether or not MAC mask is valid
+ * @param {String} value - mask value
+ * @returns {Boolean} whether or not mask is valid
+ */
+export function isMacMaskValid (value) {
+  const mask = parseInt(value, 10)
+  return mask >= macMaskMin && mask <= macMaskMax
+}
+
+/**
  * Get bits representation of IP address
  * @param {String} ipAddress - IP address in dot notation (ie 127.0.0.1)
  * @returns {String} bits
@@ -37,5 +58,16 @@ export function networkMaskValid (value) {
 export function ipAddressBits (ipAddress) {
   return ipAddress.split('.')
     .map(decimalToBinary)
+    .join('')
+}
+
+/**
+ * Get bits representation of MAC address
+ * @param {String} macAddress - MAC address (i.e. xx:xx:xx:xx:xx:xx)
+ * @returns {String} bits
+ */
+export function macAddressBits (macAddress) {
+  return macAddress.split(':')
+    .map(hexToBinary)
     .join('')
 }

--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -305,6 +305,27 @@ export default {
         options: {
           additionalProperties: false,
           properties: {
+            // the attribute for specifying data to populate the list with
+            data: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  label: {
+                    type: 'string'
+                  },
+                  value: {
+                    type: 'string'
+                  }
+                }
+              }
+            },
+
+            // the attribute to enable local filtering
+            localFiltering: {
+              type: 'boolean'
+            },
+
             // the attribute of the listed items to use as a label
             labelAttribute: {
               type: 'string'
@@ -313,6 +334,22 @@ export default {
             // description: the type of model to fetch for list-based inputs
             modelType: {
               type: 'string'
+            },
+
+            // specifies if none should be available as an option
+            none: {
+              type: 'object',
+              properties: {
+                label: {
+                  type: 'string'
+                },
+                present: {
+                  type: 'boolean'
+                },
+                value: {
+                  type: 'string'
+                }
+              }
             },
 
             // description: a hash of key/value pairs to use as query string to fetch values for list-based inputs

--- a/tests/validator/custom-formats/mac-address-test.js
+++ b/tests/validator/custom-formats/mac-address-test.js
@@ -1,0 +1,68 @@
+const expect = require('chai').expect
+
+const macAddress = require('../../../lib/validator/custom-formats/mac-address')
+
+describe('validator/custom-formats/mac-address', () => {
+  it('returns false when value is undefined', () => {
+    expect(macAddress(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', () => {
+    expect(macAddress(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', () => {
+    expect(macAddress({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', () => {
+    expect(macAddress([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', () => {
+    expect(macAddress(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', () => {
+    expect(macAddress(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', () => {
+    expect(macAddress(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', () => {
+    expect(macAddress(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when value does not consist of six groups', () => {
+    expect(macAddress('00')).to.be.equal(false)
+    expect(macAddress('00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:00')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', () => {
+    expect(macAddress('0g:00:00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:0g:00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:0g:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:0g:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:0g:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:00:0g')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', () => {
+    expect(macAddress('-01:00:00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:-01:00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:-01:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:-01:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:-01:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:00:-01')).to.be.equal(false)
+  })
+
+  it('returns true when valid MAC address', () => {
+    expect(macAddress('00:00:00:00:00:00')).to.be.equal(true)
+    expect(macAddress('01:b8:00:42:00:2e')).to.be.equal(true)
+  })
+})

--- a/tests/validator/custom-formats/mac-interface.js
+++ b/tests/validator/custom-formats/mac-interface.js
@@ -1,0 +1,81 @@
+const expect = require('chai').expect
+
+const macInterface = require('../../../lib/validator/custom-formats/mac-interface')
+
+describe('validator/custom-formats/mac-prefix', () => {
+  it('returns false when value is undefined', () => {
+    expect(macInterface(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', () => {
+    expect(macInterface(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', () => {
+    expect(macInterface({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', () => {
+    expect(macInterface([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', () => {
+    expect(macInterface(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', () => {
+    expect(macInterface(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', () => {
+    expect(macInterface(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', () => {
+    expect(macInterface(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when MAC mask is missing', () => {
+    expect(macInterface('00:00:00:00:00:00')).to.be.equal(false)
+  })
+
+  it('returns false when mac address does not consist of six groups', () => {
+    expect(macInterface('00:00:00:00:00/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', () => {
+    expect(macInterface('0g:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:0g:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:0g:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:0g:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:0g:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:00:0g/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', () => {
+    expect(macInterface('-00:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:-00:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:-00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:-00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:-00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:00:-00/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain numbers > ff', () => {
+    expect(macInterface('1ff:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:1ff:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:1ff:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:1ff:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:1ff:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:00:1ff/0')).to.be.equal(false)
+  })
+
+  it('returns false when invalid MAC prefix', () => {
+    expect(macInterface('ff:ff:00:00:00:00/16')).to.be.equal(false)
+  })
+
+  it('returns true when valid MAC prefix', () => {
+    expect(macInterface('ff:ff:ff:00:00:00/16')).to.be.equal(true)
+    expect(macInterface('ff:ff:ff:00:00:01/24')).to.be.equal(true)
+  })
+})

--- a/tests/validator/custom-formats/mac-prefix-test.js
+++ b/tests/validator/custom-formats/mac-prefix-test.js
@@ -1,0 +1,81 @@
+const expect = require('chai').expect
+
+const macPrefix = require('../../../lib/validator/custom-formats/mac-prefix')
+
+describe('validator/custom-formats/mac-prefix', () => {
+  it('returns false when value is undefined', () => {
+    expect(macPrefix(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', () => {
+    expect(macPrefix(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', () => {
+    expect(macPrefix({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', () => {
+    expect(macPrefix([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', () => {
+    expect(macPrefix(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', () => {
+    expect(macPrefix(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', () => {
+    expect(macPrefix(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', () => {
+    expect(macPrefix(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when MAC mask is missing', () => {
+    expect(macPrefix('00:00:00:00:00:00')).to.be.equal(false)
+  })
+
+  it('returns false when mac address does not consist of six groups', () => {
+    expect(macPrefix('00:00:00:00:00/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', () => {
+    expect(macPrefix('0g:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:0g:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:0g:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:0g:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:0g:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:00:0g/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', () => {
+    expect(macPrefix('-00:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:-00:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:-00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:-00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:-00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:00:-00/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain numbers > ff', () => {
+    expect(macPrefix('1ff:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:1ff:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:1ff:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:1ff:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:1ff:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:00:1ff/0')).to.be.equal(false)
+  })
+
+  it('returns false when invalid MAC prefix', () => {
+    expect(macPrefix('ff:ff:ff:00:00:00/16')).to.be.equal(false)
+  })
+
+  it('returns true when valid MAC prefix', () => {
+    expect(macPrefix('ff:ff:00:00:00:00/16')).to.be.equal(true)
+    expect(macPrefix('ff:ff:ff:00:00:00/24')).to.be.equal(true)
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** `mac-address`, `mac-prefix`, `mac-interface` format validation.
- **Added** additional properties to the `select` renderer v2 schema
