### PR TITLE
Add modelType validation

### DIFF
--- a/src/validator/cell.js
+++ b/src/validator/cell.js
@@ -51,15 +51,17 @@ export default createFactory({
    * @param {BunsenModel} model - the Model to validate model references against
    * @param {String[]} [renderers] - the list of available custom renderers to validate renderer references against
    * @param {Function} validateRenderer - function to validate a renderer
+   * @param {Function} validateModelType - function to validate model type
    * @returns {validator} the instance
    */
-  init (cellDefinitions, model, renderers, validateRenderer) {
+  init (cellDefinitions, model, renderers, validateRenderer, validateModelType) {
     renderers = renderers || []
     return _.assign(this, {
       cellDefinitions,
       cellsValidated: [],
       model,
       renderers,
+      validateModelType,
       validateRenderer
     })
   },
@@ -108,6 +110,12 @@ export default createFactory({
       !this.validateRenderer(rendererName)
     ) {
       addErrorResult(results, rendererPath, `Invalid renderer reference "${rendererName}"`)
+    }
+
+    const modelType = _.get(cell, 'renderer.options.modelType')
+
+    if (rendererName === 'select' && modelType && !this.validateModelType(modelType)) {
+      addErrorResult(results, `${rendererPath}/options`, `Invalid modelType reference "${modelType}"`)
     }
 
     return aggregateResults(results)

--- a/src/validator/cell.js
+++ b/src/validator/cell.js
@@ -100,6 +100,7 @@ export default createFactory({
       }
     ]
 
+    const modelType = _.get(cell, 'renderer.options.modelType')
     const rendererName = _.get(cell, 'renderer.name')
     const rendererPathExt = 'renderer'
     const rendererPath = `${path}/${rendererPathExt}`
@@ -111,8 +112,6 @@ export default createFactory({
     ) {
       addErrorResult(results, rendererPath, `Invalid renderer reference "${rendererName}"`)
     }
-
-    const modelType = _.get(cell, 'renderer.options.modelType')
 
     if (rendererName === 'select' && modelType && !this.validateModelType(modelType)) {
       addErrorResult(results, `${rendererPath}/options`, `Invalid modelType reference "${modelType}"`)
@@ -262,25 +261,9 @@ export default createFactory({
 
     const results = []
 
-    const attrs = Object.keys(cell)
-
-    const warnings = []
-    const knownAttributes = Object.keys(viewSchema.definitions.cell.properties)
-    attrs.forEach((attr) => {
-      if (!_.includes(knownAttributes, attr)) {
-        warnings.push({
-          path,
-          message: `Unrecognized attribute "${attr}"`
-        })
-      }
-    })
-
-    if (warnings.length > 0) {
-      results.push({
-        warnings,
-        errors: []
-      })
-    }
+    results.push(
+      this._validateCell(path, cell, model)
+    )
 
     _.forEach(cell.children, (child, index) => {
       results.push(

--- a/src/validator/index.js
+++ b/src/validator/index.js
@@ -98,9 +98,10 @@ function _validateRootAttributes (view, model, cellValidator) {
  * @param {BunsenModel} model - the JSON schema that the cells will reference
  * @param {String[]} renderers - the list of available custom renderers to validate renderer references against
  * @param {Function} validateRenderer - function to validate a renderer
+ * @param {Function} validateModelType - function to validate model type
  * @returns {BunsenValidationResult} the results of the view validation
  */
-export function validate (view, model, renderers, validateRenderer) {
+export function validate (view, model, renderers, validateRenderer, validateModelType) {
   if (view.version === '1.0') {
     view = viewV1ToV2(view)
   }
@@ -125,7 +126,9 @@ export function validate (view, model, renderers, validateRenderer) {
   }
 
   const derefModel = dereference(model).schema
-  const cellValidator = cellValidatorFactory(view.cellDefinitions, derefModel, renderers, validateRenderer)
+  const cellValidator = cellValidatorFactory(
+    view.cellDefinitions, derefModel, renderers, validateRenderer, validateModelType
+  )
   const schemaResult = _validateValue(view, viewSchema, true)
   if (schemaResult.errors.length !== 0) {
     return schemaResult

--- a/src/validator/index.js
+++ b/src/validator/index.js
@@ -38,15 +38,16 @@ function _validateCells (view, model, cellValidator) {
   }
 
   const results = _.map(view.cells, (rootCell, index) => {
+    const cellResults = []
     const path = `#/cells/${index}`
     const cellId = rootCell.extends
 
     if (cellId) {
       const cell = view.cellDefinitions[cellId]
       const cellPath = `#/cellDefinitions/${cellId}`
-      const cellResults = [
+      cellResults.push(
         validateRequiredAttribute(rootCell, path, 'extends', Object.keys(view.cellDefinitions))
-      ]
+      )
 
       if (cell !== undefined) {
         cellResults.push(
@@ -57,9 +58,11 @@ function _validateCells (view, model, cellValidator) {
       return aggregateResults(cellResults)
     }
 
-    return [
+    cellResults.push(
       cellValidator.validate(`#/cells/${index}`, rootCell)
-    ]
+    )
+
+    return aggregateResults(cellResults)
   })
 
   return aggregateResults(results)

--- a/tests/validator/index-test.js
+++ b/tests/validator/index-test.js
@@ -121,7 +121,11 @@ describe('validator', () => {
             return rendererName === 'foo-bar-renderer'
           }
 
-          result = validator.validate(view, model, renderers, validateRenderer)
+          function validateModelType () {
+            return true
+          }
+
+          result = validator.validate(view, model, renderers, validateRenderer, validateModelType)
         })
 
         it('returns proper result', () => {
@@ -191,12 +195,130 @@ describe('validator', () => {
         return rendererName === 'foo-bar-renderer'
       }
 
-      result = validator.validate(view, model, renderers, validateRenderer)
+      function validateModelType () {
+        return true
+      }
+
+      result = validator.validate(view, model, renderers, validateRenderer, validateModelType)
     })
 
     it('returns proper result', () => {
       expect(result).deep.equal({
         errors: [],
+        warnings: []
+      })
+    })
+  })
+
+  describe('when modelType is invalid on root cell', function () {
+    var result
+
+    beforeEach(function () {
+      const model = {
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        },
+        type: 'object'
+      }
+
+      const view = {
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'select',
+              options: {
+                modelType: 'bar'
+              }
+            }
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      }
+
+      const renderers = []
+
+      function validateRenderer (rendererName) {
+        return true
+      }
+
+      function validateModelType () {
+        return false
+      }
+
+      result = validator.validate(view, model, renderers, validateRenderer, validateModelType)
+    })
+
+    it('returns proper result', () => {
+      expect(result).deep.equal({
+        errors: [
+          {
+            message: 'Invalid modelType reference "bar"',
+            path: '#/cells/0/renderer/options'
+          }
+        ],
+        warnings: []
+      })
+    })
+  })
+
+  describe('when modelType is invalid on root cell child', function () {
+    var result
+
+    beforeEach(function () {
+      const model = {
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        },
+        type: 'object'
+      }
+
+      const view = {
+        cells: [
+          {
+            children: [
+              {
+                model: 'foo',
+                renderer: {
+                  name: 'select',
+                  options: {
+                    modelType: 'bar'
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        type: 'form',
+        version: '2.0'
+      }
+
+      const renderers = []
+
+      function validateRenderer (rendererName) {
+        return true
+      }
+
+      function validateModelType () {
+        return false
+      }
+
+      result = validator.validate(view, model, renderers, validateRenderer, validateModelType)
+    })
+
+    it('returns proper result', () => {
+      expect(result).deep.equal({
+        errors: [
+          {
+            message: 'Invalid modelType reference "bar"',
+            path: '#/cells/0/children/0/renderer/options'
+          }
+        ],
         warnings: []
       })
     })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** validation of the `modelType` option for select renderers.
- **Fixed** an issue where proper validation wasn't being run against root cells.
