### PR TITLE
Make utils less brittle

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -140,6 +140,10 @@ export function findValue (obj, valuePath, startPath = '') {
  * @throws Will throw when any value at the resolved path is empty
  */
 export function parseVariables (valueObj, queryJSON, startPath = '', allowEmpty = false) {
+  if (!queryJSON) {
+    return {}
+  }
+
   if (queryJSON.indexOf('${') !== -1) {
     const valueVariable = queryJSON.split('${')[1].split('}')[0]
     let result = findValue(valueObj, valueVariable, startPath)
@@ -155,6 +159,7 @@ export function parseVariables (valueObj, queryJSON, startPath = '', allowEmpty 
     const newQueryJson = queryJSON.split('${' + valueVariable + '}').join(result)
     return parseVariables(valueObj, newQueryJson, startPath, allowEmpty)
   }
+
   return queryJSON
 }
 
@@ -166,7 +171,7 @@ export function parseVariables (valueObj, queryJSON, startPath = '', allowEmpty 
  * @returns {Object} the populated query
  */
 export function populateQuery (valueObj, query, startPath = '') {
-  return JSON.parse(parseVariables(valueObj, JSON.stringify(query), startPath))
+  return JSON.parse(parseVariables(valueObj, JSON.stringify(query || {}), startPath))
 }
 
 /**

--- a/tests/utils-test.js
+++ b/tests/utils-test.js
@@ -98,4 +98,20 @@ describe('utils', () => {
       expect(JSON.stringify(actual)).to.equal(JSON.stringify(expected))
     })
   })
+
+  describe('.parseVariables()', function () {
+    it('does not throw error when queryJSON not present', function () {
+      expect(() => {
+        utils.parseVariables({}, undefined)
+      }).not.to.throw()
+    })
+  })
+
+  describe('.populateQuery()', function () {
+    it('does not throw error when query not present', function () {
+      expect(() => {
+        utils.populateQuery({}, undefined)
+      }).not.to.throw()
+    })
+  })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** utility methods not to be less brittle and not throw an error when query isn't present.
