### PR TITLE
Fix populateQuery() to not thorw error

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -171,7 +171,12 @@ export function parseVariables (valueObj, queryJSON, startPath = '', allowEmpty 
  * @returns {Object} the populated query
  */
 export function populateQuery (valueObj, query, startPath = '') {
-  return JSON.parse(parseVariables(valueObj, JSON.stringify(query || {}), startPath))
+  try {
+    return JSON.parse(parseVariables(valueObj, JSON.stringify(query || {}), startPath))
+  } catch (err) {
+    console.warn(err)
+    return {}
+  }
 }
 
 /**

--- a/tests/utils-test.js
+++ b/tests/utils-test.js
@@ -113,5 +113,11 @@ describe('utils', () => {
         utils.populateQuery({}, undefined)
       }).not.to.throw()
     })
+
+    it('does not throw error when query dependency is not present', function () {
+      expect(function () {
+        utils.populateQuery({}, {node: '${./node}'})
+      }).not.to.throw()
+    })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** `populateQuery()` to not throw error.
