### PR TITLE
Fixed issue where `hasValidQuery` was simply incorrect

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,7 @@ export function populateQuery (valueObj, query, startPath = '') {
     return JSON.parse(parseVariables(valueObj, JSON.stringify(query || {}), startPath))
   } catch (err) {
     console.warn(err)
-    return {}
+    return null
   }
 }
 
@@ -192,10 +192,9 @@ export function hasValidQueryValues (value, queryDef, startPath) {
     return true
   }
 
-  try {
-    const query = populateQuery(value, queryDef, startPath)
-    return Object.keys(query).every((key) => String(query[key]) !== '')
-  } catch (e) {
+  const query = populateQuery(value, queryDef, startPath)
+  if (!query) {
     return false
   }
+  return Object.keys(query).every((key) => String(query[key]) !== '')
 }

--- a/tests/utils-test.js
+++ b/tests/utils-test.js
@@ -114,6 +114,14 @@ describe('utils', () => {
       }).not.to.throw()
     })
 
+    it('does not return null when query is not present', function () {
+      expect(utils.populateQuery({}, undefined)).not.to.be.null
+    })
+
+    it('does not return null when query is empty', function () {
+      expect(utils.populateQuery({}, {})).not.to.be.null
+    })
+
     it('does not throw error when query dependency is not present', function () {
       expect(function () {
         utils.populateQuery({}, {node: '${./node}'})

--- a/tests/utils-test.js
+++ b/tests/utils-test.js
@@ -119,5 +119,9 @@ describe('utils', () => {
         utils.populateQuery({}, {node: '${./node}'})
       }).not.to.throw()
     })
+
+    it('returns null when query dependency is not present', function () {
+      expect(utils.populateQuery({}, {node: '${./node}'})).to.be.null
+    })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** `hasValidQuery` to return false when `populateQuery` fails on lookup.
