### PR TITLE
Allow more value types on the selectRenderer options and allow /multicast in mac mask validation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -174,7 +174,6 @@ export function populateQuery (valueObj, query, startPath = '') {
   try {
     return JSON.parse(parseVariables(valueObj, JSON.stringify(query || {}), startPath))
   } catch (err) {
-    console.warn(err)
     return null
   }
 }

--- a/src/validator/custom-formats/mac-interface.js
+++ b/src/validator/custom-formats/mac-interface.js
@@ -1,5 +1,5 @@
 import isMacAddress from './mac-address'
-import {isMacMaskValid, macAddressBits} from './utils'
+import {isMacMaskValid, macAddressBits, macMulticastMaskRegex, isMacMulticastAddress} from './utils'
 
 /**
  * Validate value as an MAC address interface
@@ -19,6 +19,10 @@ export default function (value) {
 
   if (!isMacMaskValid(mask)) {
     return false
+  }
+
+  if (macMulticastMaskRegex.test(mask)) {
+    return isMacMulticastAddress(value)
   }
 
   const bits = macAddressBits(macAddress)

--- a/src/validator/custom-formats/mac-prefix.js
+++ b/src/validator/custom-formats/mac-prefix.js
@@ -1,5 +1,5 @@
 import isMacAddress from './mac-address'
-import {isMacMaskValid, macAddressBits} from './utils'
+import {isMacMaskValid, macAddressBits, macMulticastMaskRegex, isMacMulticastAddress} from './utils'
 
 /**
  * Validate value as an MAC address prefix
@@ -22,6 +22,11 @@ export default function (value) {
   }
 
   const bits = macAddressBits(macAddress)
+
+  if (macMulticastMaskRegex.test(mask)) {
+    return isMacMulticastAddress(value)
+  }
+
   const hostBits = bits.slice(parseInt(mask, 10))
 
   return /^0+$/.test(hostBits)

--- a/src/validator/custom-formats/utils.js
+++ b/src/validator/custom-formats/utils.js
@@ -2,6 +2,8 @@ export const networkMaskMax = 32
 export const networkMaskMin = 0
 export const macMaskMax = 48
 export const macMaskMin = 0
+export const macMulticastMaskRegex = /^multicast$/i
+export const macMulticastBit = 7
 
 /**
  * Convert decimal value to binary representation
@@ -46,8 +48,22 @@ export function networkMaskValid (value) {
  * @returns {Boolean} whether or not mask is valid
  */
 export function isMacMaskValid (value) {
+  // Ciena allows /multicast as an option for the mask
+  if (macMulticastMaskRegex.test(value)) {
+    return true
+  }
+
   const mask = parseInt(value, 10)
   return mask >= macMaskMin && mask <= macMaskMax
+}
+
+/**
+ * Tests whether the address is a valid multicast address
+ * @param {String} value - mac address value
+ * @returns {Boolean} whether the address is a valid multicast address
+ */
+export function isMacMulticastAddress (value) {
+  return macAddressBits(value).charAt(macMulticastBit) === '1'
 }
 
 /**

--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -315,7 +315,7 @@ export default {
                     type: 'string'
                   },
                   value: {
-                    type: ['string', 'number', 'boolean']
+                    type: ['string', 'number', 'integer', 'boolean', 'object']
                   }
                 }
               }
@@ -347,7 +347,7 @@ export default {
                   type: 'boolean'
                 },
                 value: {
-                  type: 'string'
+                  type: ['string', 'number', 'integer', 'boolean', 'object']
                 }
               }
             },

--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -315,7 +315,7 @@ export default {
                     type: 'string'
                   },
                   value: {
-                    type: 'string'
+                    type: ['string', 'number', 'boolean']
                   }
                 }
               }

--- a/tests/validator/custom-formats/mac-interface-test.js
+++ b/tests/validator/custom-formats/mac-interface-test.js
@@ -72,10 +72,12 @@ describe('validator/custom-formats/mac-prefix', () => {
 
   it('returns false when invalid MAC prefix', () => {
     expect(macInterface('ff:ff:00:00:00:00/16')).to.be.equal(false)
+    expect(macInterface('f0:ff:00:00:00:00/multicast')).to.be.equal(false)
   })
 
   it('returns true when valid MAC prefix', () => {
     expect(macInterface('ff:ff:ff:00:00:00/16')).to.be.equal(true)
     expect(macInterface('ff:ff:ff:00:00:01/24')).to.be.equal(true)
+    expect(macInterface('ff:ff:ff:00:00:01/multicast')).to.be.equal(true)
   })
 })

--- a/tests/validator/custom-formats/mac-prefix-test.js
+++ b/tests/validator/custom-formats/mac-prefix-test.js
@@ -70,12 +70,14 @@ describe('validator/custom-formats/mac-prefix', () => {
     expect(macPrefix('00:00:00:00:00:1ff/0')).to.be.equal(false)
   })
 
-  it('returns false when invalid MAC prefix', () => {
+  it('returns false when invalid MAC interface', () => {
     expect(macPrefix('ff:ff:ff:00:00:00/16')).to.be.equal(false)
+    expect(macPrefix('f0:ff:ff:00:00:00/multicast')).to.be.equal(false)
   })
 
-  it('returns true when valid MAC prefix', () => {
+  it('returns true when valid MAC interface', () => {
     expect(macPrefix('ff:ff:00:00:00:00/16')).to.be.equal(true)
     expect(macPrefix('ff:ff:ff:00:00:00/24')).to.be.equal(true)
+    expect(macPrefix('ff:ff:ff:00:00:00/multicast')).to.be.equal(true)
   })
 })

--- a/tests/validator/view-schema/v2-test.js
+++ b/tests/validator/view-schema/v2-test.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const expect = require('chai').expect
+const ZSchema = require('z-schema')
+const model = require('../../../lib/validator/view-schemas/v2')
+
+describe('v2 schema validation', () => {
+  let schemaValidator
+  beforeEach(function () {
+    schemaValidator = new ZSchema({
+      breakOnFirstError: false
+    })
+  })
+
+  describe('selectRenderer', function () {
+    let value
+    beforeEach(function () {
+      value = {
+        type: 'form',
+        version: '2.0',
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'select',
+              options: {
+                data: [{
+                  label: 'label',
+                  value: 'value'
+                }],
+                none: {
+                  label: 'None',
+                  present: true,
+                  value: ''
+                }
+              }
+            }
+          }
+        ]
+      }
+    })
+
+    describe('when data value is specified', function () {
+      it('passes validation when value is string', function () {
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('passes validation when value is number', function () {
+        value.cells[0].renderer.options.data[0].value = 1.1
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('passes validation when value is integer', function () {
+        value.cells[0].renderer.options.data[0].value = 1
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+      it('passes validation when value is boolean', function () {
+        value.cells[0].renderer.options.data[0].value = true
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+      it('passes validation when value is object', function () {
+        value.cells[0].renderer.options.data[0].value = {}
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('fails validation when value is an array', function () {
+        value.cells[0].renderer.options.data[0].value = []
+        expect(schemaValidator.validate(value, model)).to.equal(false)
+      })
+
+      it('fails validation when value is null', function () {
+        value.cells[0].renderer.options.data[0].value = null
+        expect(schemaValidator.validate(value, model)).to.equal(false)
+      })
+    })
+
+    describe('when none value is specified', function () {
+      it('passes validation when value is string', function () {
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('passes validation when value is number', function () {
+        value.cells[0].renderer.options.none.value = 1.1
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('passes validation when value is integer', function () {
+        value.cells[0].renderer.options.none.value = 1
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+      it('passes validation when value is boolean', function () {
+        value.cells[0].renderer.options.none.value = true
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+      it('passes validation when value is object', function () {
+        value.cells[0].renderer.options.none.value = {}
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('fails validation when value is an array', function () {
+        value.cells[0].renderer.options.none.value = []
+        expect(schemaValidator.validate(value, model)).to.equal(false)
+      })
+
+      it('fails validation when value is null', function () {
+        value.cells[0].renderer.options.none.value = null
+        expect(schemaValidator.validate(value, model)).to.equal(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** Selects can be used with values other than string. This adds supports for numbers and booleans.
