### PR TITLE
Fix parseVariables to return correct data type

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -141,7 +141,7 @@ export function findValue (obj, valuePath, startPath = '') {
  */
 export function parseVariables (valueObj, queryJSON, startPath = '', allowEmpty = false) {
   if (!queryJSON) {
-    return {}
+    return ''
   }
 
   if (queryJSON.indexOf('${') !== -1) {

--- a/tests/utils-test.js
+++ b/tests/utils-test.js
@@ -100,10 +100,8 @@ describe('utils', () => {
   })
 
   describe('.parseVariables()', function () {
-    it('does not throw error when queryJSON not present', function () {
-      expect(() => {
-        utils.parseVariables({}, undefined)
-      }).not.to.throw()
+    it('returns an empty string when queryJSON not present', function () {
+      expect(utils.parseVariables({}, undefined)).to.equal('')
     })
   })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** `parseVariables()` to return correct data type.
