### PR TITLE
Allow consumer to force re-validation when value is the same

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -138,7 +138,7 @@ export function validate (
       (_.isObject(inputValue) && Object.keys(inputValue).length === 0) // Check if empty object
     )
 
-    const previousValue = !bunsenId ? formValue : _.get(formValue, bunsenId)
+    const previousValue = _.get(formValue, bunsenId)
 
     // If an empty value has been provided and there is no previous value then
     // make sure to apply defaults from the model

--- a/src/actions.js
+++ b/src/actions.js
@@ -118,7 +118,18 @@ function findDefaults (value, path, model, resolveRef) {
   return schemaDefault
 }
 
-export function validate (bunsenId, inputValue, renderModel, validators, all = Promise.all) {
+/**
+ * Validate action
+ * @param {String} bunsenId - bunsen ID of what changed
+ * @param {Object} inputValue - value of what changed
+ * @param {Object} renderModel - bunsen model
+ * @param {Array<Function>} validators - custom validators
+ * @param {Function} [all=Promise.all] - framework specific Promise.all method
+ * @param {Boolean} [forceValidation=false] - whether or not to force validation
+ */
+export function validate (
+  bunsenId, inputValue, renderModel, validators, all = Promise.all, forceValidation = false
+) {
   return function (dispatch, getState) {
     let formValue = getState().value
 
@@ -127,7 +138,7 @@ export function validate (bunsenId, inputValue, renderModel, validators, all = P
       (_.isObject(inputValue) && Object.keys(inputValue).length === 0) // Check if empty object
     )
 
-    const previousValue = _.get(formValue, bunsenId)
+    const previousValue = !bunsenId ? formValue : _.get(formValue, bunsenId)
 
     // If an empty value has been provided and there is no previous value then
     // make sure to apply defaults from the model
@@ -142,8 +153,9 @@ export function validate (bunsenId, inputValue, renderModel, validators, all = P
       }
     }
 
-    // if the value never changed, no need to update and validate
-    if (_.isEqual(inputValue, previousValue)) {
+    // if the value never changed, no need to update and validate (unless consumer
+    // is forcing validation again)
+    if (!forceValidation && _.isEqual(inputValue, previousValue)) {
       return
     }
 

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -288,49 +288,98 @@ describe('validate action', function () {
       }
     })
 
-    it('does not dispatch any actions', function () {
-      var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [])
+    describe('check entire form for changes', function () {
+      it('does not dispatch any actions', function () {
+        var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [])
 
-      thunk(
-        function (action) {
-          count += 1
-        },
-        function () {
-          return _.cloneDeep(state)
-        }
-      )
+        thunk(
+          function (action) {
+            count += 1
+          },
+          function () {
+            return _.cloneDeep(state)
+          }
+        )
 
-      expect(count, 'dispatches nothing').to.equal(0)
+        expect(count, 'dispatches nothing').to.equal(0)
+      })
+
+      it('dispatches actions when forceValidation is disabled', function () {
+        var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [], Promise.all, false)
+
+        thunk(
+          function (action) {
+            count += 1
+          },
+          function () {
+            return _.cloneDeep(state)
+          }
+        )
+
+        expect(count, 'dispatches nothing').to.equal(0)
+      })
+
+      it('dispatches actions when forceValidation is enabled', function () {
+        var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [], Promise.all, true)
+
+        thunk(
+          function (action) {
+            count += 1
+          },
+          function () {
+            return _.cloneDeep(state)
+          }
+        )
+
+        expect(count, 'dispatches nothing').to.equal(1)
+      })
     })
 
-    it('dispatches actions when forceValidation is disabled', function () {
-      var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [], Promise.all, false)
+    describe('check property for changes', function () {
+      it('does not dispatch any actions', function () {
+        var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [])
 
-      thunk(
-        function (action) {
-          count += 1
-        },
-        function () {
-          return _.cloneDeep(state)
-        }
-      )
+        thunk(
+          function (action) {
+            count += 1
+          },
+          function () {
+            return _.cloneDeep(state)
+          }
+        )
 
-      expect(count, 'dispatches nothing').to.equal(0)
-    })
+        expect(count, 'dispatches nothing').to.equal(0)
+      })
 
-    it('dispatches actions when forceValidation is enabled', function () {
-      var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [], Promise.all, true)
+      it('dispatches actions when forceValidation is disabled', function () {
+        var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [], Promise.all, false)
 
-      thunk(
-        function (action) {
-          count += 1
-        },
-        function () {
-          return _.cloneDeep(state)
-        }
-      )
+        thunk(
+          function (action) {
+            count += 1
+          },
+          function () {
+            return _.cloneDeep(state)
+          }
+        )
 
-      expect(count, 'dispatches nothing').to.equal(1)
+        expect(count, 'dispatches nothing').to.equal(0)
+      })
+
+      it('dispatches actions when forceValidation is enabled', function () {
+        var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [], Promise.all, true)
+
+        thunk(
+          function (action) {
+            count += 1
+          },
+          function () {
+            return _.cloneDeep(state)
+          }
+        )
+
+        expect(count, 'dispatches nothing').to.equal(1)
+      })
     })
   })
 

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -302,7 +302,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(spy.callCount, 'dispatches nothing').to.equal(1)
+        expect(spy.callCount).to.equal(1)
       })
 
       it('dispatches action when forceValidation is disabled', function () {
@@ -315,7 +315,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(spy.callCount, 'dispatches nothing').to.equal(1)
+        expect(spy.callCount).to.equal(1)
       })
 
       it('dispatches action when forceValidation is enabled', function () {
@@ -328,7 +328,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(spy.callCount, 'dispatches nothing').to.equal(1)
+        expect(spy.callCount).to.equal(1)
       })
     })
 
@@ -343,7 +343,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(spy.callCount, 'dispatches nothing').to.equal(0)
+        expect(spy.callCount).to.equal(0)
       })
 
       it('does not dispatch action when forceValidation is disabled', function () {
@@ -356,7 +356,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(spy.callCount, 'dispatches nothing').to.equal(0)
+        expect(spy.callCount).to.equal(0)
       })
 
       it('dispatches action when forceValidation is enabled', function () {
@@ -369,7 +369,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(spy.callCount, 'dispatches nothing').to.equal(1)
+        expect(spy.callCount).to.equal(1)
       })
     })
   })

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect
 var actions = require('../lib/actions')
 var _ = require('lodash')
+var sinon = require('sinon')
 
 describe('changeValue action', function () {
   it(`returns a dispatcher action with type "${actions.CHANGE_VALUE}"`, function () {
@@ -276,11 +277,11 @@ describe('validate action', function () {
   })
 
   describe('when value is the same', function () {
-    var count, schema, state
+    var schema, state, spy
 
     beforeEach(function () {
-      count = 0
       schema = _.cloneDeep(SCHEMA_WITH_NO_DEFAULTS)
+      spy = sinon.spy()
       state = {
         value: {
           alias: 'Bob'
@@ -291,96 +292,84 @@ describe('validate action', function () {
     // NOTE: the full form value always re-triggers validation. Otherwise we get
     // ourselves into a state where defaults aren't applied.
     describe('check entire form for changes', function () {
-      it('dispatches actions', function () {
+      it('dispatches action', function () {
         var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [])
 
         thunk(
-          function (action) {
-            count += 1
-          },
+          spy,
           function () {
             return _.cloneDeep(state)
           }
         )
 
-        expect(count, 'dispatches nothing').to.equal(1)
+        expect(spy.callCount, 'dispatches nothing').to.equal(1)
       })
 
-      it('dispatches actions when forceValidation is disabled', function () {
+      it('dispatches action when forceValidation is disabled', function () {
         var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [], Promise.all, false)
 
         thunk(
-          function (action) {
-            count += 1
-          },
+          spy,
           function () {
             return _.cloneDeep(state)
           }
         )
 
-        expect(count, 'dispatches nothing').to.equal(1)
+        expect(spy.callCount, 'dispatches nothing').to.equal(1)
       })
 
-      it('dispatches actions when forceValidation is enabled', function () {
+      it('dispatches action when forceValidation is enabled', function () {
         var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [], Promise.all, true)
 
         thunk(
-          function (action) {
-            count += 1
-          },
+          spy,
           function () {
             return _.cloneDeep(state)
           }
         )
 
-        expect(count, 'dispatches nothing').to.equal(1)
+        expect(spy.callCount, 'dispatches nothing').to.equal(1)
       })
     })
 
     describe('check property for changes', function () {
-      it('does not dispatch actions', function () {
+      it('does not dispatch action', function () {
         var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [])
 
         thunk(
-          function (action) {
-            count += 1
-          },
+          spy,
           function () {
             return _.cloneDeep(state)
           }
         )
 
-        expect(count, 'dispatches nothing').to.equal(0)
+        expect(spy.callCount, 'dispatches nothing').to.equal(0)
       })
 
-      it('does not dispatch actions when forceValidation is disabled', function () {
+      it('does not dispatch action when forceValidation is disabled', function () {
         var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [], Promise.all, false)
 
         thunk(
-          function (action) {
-            count += 1
-          },
+          spy,
           function () {
             return _.cloneDeep(state)
           }
         )
 
-        expect(count, 'dispatches nothing').to.equal(0)
+        expect(spy.callCount, 'dispatches nothing').to.equal(0)
       })
 
-      it('dispatches actions when forceValidation is enabled', function () {
+      it('dispatches action when forceValidation is enabled', function () {
         var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [], Promise.all, true)
 
         thunk(
-          function (action) {
-            count += 1
-          },
+          spy,
           function () {
             return _.cloneDeep(state)
           }
         )
 
-        expect(count, 'dispatches nothing').to.equal(1)
+        expect(spy.callCount, 'dispatches nothing').to.equal(1)
       })
     })
   })

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -275,6 +275,65 @@ describe('validate action', function () {
     }, getState)
   })
 
+  describe('when value is the same', function () {
+    var count, schema, state
+
+    beforeEach(function () {
+      count = 0
+      schema = _.cloneDeep(SCHEMA_WITH_NO_DEFAULTS)
+      state = {
+        value: {
+          alias: 'Bob'
+        }
+      }
+    })
+
+    it('does not dispatch any actions', function () {
+      var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [])
+
+      thunk(
+        function (action) {
+          count += 1
+        },
+        function () {
+          return _.cloneDeep(state)
+        }
+      )
+
+      expect(count, 'dispatches nothing').to.equal(0)
+    })
+
+    it('dispatches actions when forceValidation is disabled', function () {
+      var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [], Promise.all, false)
+
+      thunk(
+        function (action) {
+          count += 1
+        },
+        function () {
+          return _.cloneDeep(state)
+        }
+      )
+
+      expect(count, 'dispatches nothing').to.equal(0)
+    })
+
+    it('dispatches actions when forceValidation is enabled', function () {
+      var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [], Promise.all, true)
+
+      thunk(
+        function (action) {
+          count += 1
+        },
+        function () {
+          return _.cloneDeep(state)
+        }
+      )
+
+      expect(count, 'dispatches nothing').to.equal(1)
+    })
+  })
+
   it('handles defaults for new array elements', function () {
     var defaultValue = getDefaultValue('superheroes.0', {}, SCHEMA_WITH_ARRAY_DEFAULTS)
 

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -288,8 +288,10 @@ describe('validate action', function () {
       }
     })
 
+    // NOTE: the full form value always re-triggers validation. Otherwise we get
+    // ourselves into a state where defaults aren't applied.
     describe('check entire form for changes', function () {
-      it('does not dispatch any actions', function () {
+      it('dispatches actions', function () {
         var thunk = actions.validate(null, _.cloneDeep(state.value), schema, [])
 
         thunk(
@@ -301,7 +303,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(count, 'dispatches nothing').to.equal(0)
+        expect(count, 'dispatches nothing').to.equal(1)
       })
 
       it('dispatches actions when forceValidation is disabled', function () {
@@ -316,7 +318,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(count, 'dispatches nothing').to.equal(0)
+        expect(count, 'dispatches nothing').to.equal(1)
       })
 
       it('dispatches actions when forceValidation is enabled', function () {
@@ -336,7 +338,7 @@ describe('validate action', function () {
     })
 
     describe('check property for changes', function () {
-      it('does not dispatch any actions', function () {
+      it('does not dispatch actions', function () {
         var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [])
 
         thunk(
@@ -351,7 +353,7 @@ describe('validate action', function () {
         expect(count, 'dispatches nothing').to.equal(0)
       })
 
-      it('dispatches actions when forceValidation is disabled', function () {
+      it('does not dispatch actions when forceValidation is disabled', function () {
         var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [], Promise.all, false)
 
         thunk(


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** new `forceValidation` argument to `validate` action to allow consumer to force re-validation when the value is the same.

