### PR TITLE
BPSO-35979: /32 ipv4-prefix validation

### DIFF
--- a/src/validator/custom-formats/ipv4-prefix.js
+++ b/src/validator/custom-formats/ipv4-prefix.js
@@ -35,6 +35,8 @@ export default function (value) {
 
   const bits = ipAddressBits(ipAddress)
   const zeroBits = bits.slice(parseInt(networkMask, 10))
-
+  if (networkMask === '32') {
+    return !zeroBits.length
+  }
   return /^0+$/.test(zeroBits)
 }

--- a/src/validator/custom-formats/ipv4-prefix.js
+++ b/src/validator/custom-formats/ipv4-prefix.js
@@ -35,8 +35,9 @@ export default function (value) {
 
   const bits = ipAddressBits(ipAddress)
   const zeroBits = bits.slice(parseInt(networkMask, 10))
+
   if (networkMask === '32') {
-    return !zeroBits.length
+    return zeroBits.length === 0
   }
   return /^0+$/.test(zeroBits)
 }

--- a/tests/validator/custom-formats/ipv4-prefix-test.js
+++ b/tests/validator/custom-formats/ipv4-prefix-test.js
@@ -74,7 +74,9 @@ describe('validator/custom-formats/ipv4-prefix', () => {
   })
 
   it('returns true when valid IPv4 prefix', () => {
+    expect(ipv4Prefix('192.0.0.0/8')).to.be.equal(true)
     expect(ipv4Prefix('192.168.0.0/16')).to.be.equal(true)
     expect(ipv4Prefix('192.168.104.0/24')).to.be.equal(true)
+    expect(ipv4Prefix('192.168.104.5/32')).to.be.equal(true)
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* added support for 192.168.1.5/32 (entire address is network) ipv4 prefix values.  edge case but it is valid CIDR

