### PR TITLE
Ignoring deletes and arrays for computing patches

### DIFF
--- a/src/change-utils.js
+++ b/src/change-utils.js
@@ -102,7 +102,7 @@ export function computePatch (oldValue, newValue) {
       const matches = pathId.match(indexRegex)
       if (matches) {
         const arrayAnc = matches[1] || ''
-        _.set(diff, arrayAnc, _.get(newValue, arrayAnc))
+        _.set(diff, arrayAnc, _.cloneDeep(_.get(newValue, arrayAnc)))
       } else {
         _.set(diff, pathId, changeSet.value)
       }

--- a/tests/change-utils-test.js
+++ b/tests/change-utils-test.js
@@ -161,27 +161,35 @@ describe('change-utils', function () {
         })
       })
 
-      it('when a nested array item is modified', function () {
+      it('when a deeply nested array item is modified', function () {
         const result = changeUtils.computePatch({
-          fooParent: [{
-            foo: ['bar', 'baz']
-          }, {
-            foo: ['bar', 'baz']
-          }]
+          lorem: {
+            fooParent: [{
+              foo: ['bar', 'baz']
+            }, {
+              foo: ['bar', 'baz']
+            }]
+          },
+          ipsum: 'dolor'
         }, {
-          fooParent: [{
-            foo: ['bar', 'baz']
-          }, {
-            foo: ['bar', 'qux']
-          }]
+          lorem: {
+            fooParent: [{
+              foo: ['bar', 'baz']
+            }, {
+              foo: ['bar', 'qux']
+            }]
+          },
+          ipsum: 'dolor'
         })
 
         expect(result).to.eql({
-          fooParent: [{
-            foo: ['bar', 'baz']
-          }, {
-            foo: ['bar', 'qux']
-          }]
+          lorem: {
+            fooParent: [{
+              foo: ['bar', 'baz']
+            }, {
+              foo: ['bar', 'qux']
+            }]
+          }
         })
       })
     })
@@ -193,6 +201,16 @@ describe('change-utils', function () {
         }, {
           foo: 'bar'
         })
+        expect(result).to.eql({})
+      })
+
+      it('when an array is unmodified', function () {
+        const result = changeUtils.computePatch({
+          foo: ['bar', 'baz']
+        }, {
+          foo: ['bar', 'baz']
+        })
+
         expect(result).to.eql({})
       })
     })
@@ -243,25 +261,33 @@ describe('change-utils', function () {
 
       it('when a nested array item is modified', function () {
         const result = changeUtils.computePatch({
-          fooParent: [{
-            foo: ['bar', 'baz']
-          }, {
-            foo: ['bar', 'baz']
-          }]
+          lorem: {
+            fooParent: [{
+              foo: ['bar', 'baz']
+            }, {
+              foo: ['bar', 'baz']
+            }]
+          },
+          ipsum: 'dolor'
         }, {
-          fooParent: [{
-            foo: ['bar', 'baz']
-          }, {
-            foo: ['bar', 'baz', 'qux']
-          }]
+          lorem: {
+            fooParent: [{
+              foo: ['bar', 'baz']
+            }, {
+              foo: ['bar', 'baz', 'qux']
+            }]
+          },
+          ipsum: 'dolor'
         })
 
         expect(result).to.eql({
-          fooParent: [{
-            foo: ['bar', 'baz']
-          }, {
-            foo: ['bar', 'baz', 'qux']
-          }]
+          lorem: {
+            fooParent: [{
+              foo: ['bar', 'baz']
+            }, {
+              foo: ['bar', 'baz', 'qux']
+            }]
+          }
         })
       })
     })

--- a/tests/change-utils-test.js
+++ b/tests/change-utils-test.js
@@ -84,7 +84,7 @@ describe('change-utils', function () {
   })
 
   describe('computePatch', function () {
-    describe('computes the right values for removed values', function () {
+    describe('computes the right values for modified values', function () {
       it('when a leaf node is set to undefined', function () {
         const result = changeUtils.computePatch({
           foo: 'bar'
@@ -123,9 +123,7 @@ describe('change-utils', function () {
           foo: {}
         })
       })
-    })
 
-    describe('computes the right values for modified values', function () {
       it('when a leaf node is updated', function () {
         const result = changeUtils.computePatch({
           foo: 'bar'
@@ -148,6 +146,42 @@ describe('change-utils', function () {
 
         expect(result).to.eql({
           foo: 'bar'
+        })
+      })
+
+      it('when an array item is modified', function () {
+        const result = changeUtils.computePatch({
+          foo: ['bar', 'baz']
+        }, {
+          foo: ['bar', 'qux']
+        })
+
+        expect(result).to.eql({
+          foo: ['bar', 'qux']
+        })
+      })
+
+      it('when a nested array item is modified', function () {
+        const result = changeUtils.computePatch({
+          fooParent: [{
+            foo: ['bar', 'baz']
+          }, {
+            foo: ['bar', 'baz']
+          }]
+        }, {
+          fooParent: [{
+            foo: ['bar', 'baz']
+          }, {
+            foo: ['bar', 'qux']
+          }]
+        })
+
+        expect(result).to.eql({
+          fooParent: [{
+            foo: ['bar', 'baz']
+          }, {
+            foo: ['bar', 'qux']
+          }]
         })
       })
     })
@@ -192,6 +226,42 @@ describe('change-utils', function () {
           foo: {
             baz: 'qux'
           }
+        })
+      })
+
+      it('when an array item is added to', function () {
+        const result = changeUtils.computePatch({
+          foo: ['bar', 'baz']
+        }, {
+          foo: ['bar', 'baz', 'qux']
+        })
+
+        expect(result).to.eql({
+          foo: ['bar', 'baz', 'qux']
+        })
+      })
+
+      it('when a nested array item is modified', function () {
+        const result = changeUtils.computePatch({
+          fooParent: [{
+            foo: ['bar', 'baz']
+          }, {
+            foo: ['bar', 'baz']
+          }]
+        }, {
+          fooParent: [{
+            foo: ['bar', 'baz']
+          }, {
+            foo: ['bar', 'baz', 'qux']
+          }]
+        })
+
+        expect(result).to.eql({
+          fooParent: [{
+            foo: ['bar', 'baz']
+          }, {
+            foo: ['bar', 'baz', 'qux']
+          }]
         })
       })
     })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Removed** the processing of deletes in the `computePatch` since only `add/updates` are the only operations required.
* **Fixed** issue where a previous value of empty would cause an empty path id
* Ignored arrays since it doesn't make sense to send partial arrays
