### PR TITLE
Actually include new formats

### DIFF
--- a/src/validator/custom-formats/index.js
+++ b/src/validator/custom-formats/index.js
@@ -10,6 +10,9 @@ import ipv4Address from './ipv4-address'
 import ipv4Interface from './ipv4-interface'
 import ipv4Prefix from './ipv4-prefix'
 import ipv6Address from './ipv6-address'
+import ipv6Interface from './ipv6-interface'
+import ipv6Multicast from './ipv6-multicast'
+import ipv6Prefix from './ipv6-prefix'
 import macAddress from './mac-address'
 import macInterface from './mac-interface'
 import macPrefix from './mac-prefix'
@@ -36,6 +39,9 @@ export default {
   'ipv4-interface': ipv4Interface,
   'ipv4-prefix': ipv4Prefix,
   'ipv6-address': ipv6Address,
+  'ipv6-interface': ipv6Interface,
+  'ipv6-multicast': ipv6Multicast,
+  'ipv6-prefix': ipv6Prefix,
   netmask,
   'mac-address': macAddress,
   'mac-interface': macInterface,

--- a/tests/validator/custom-formats/index-test.js
+++ b/tests/validator/custom-formats/index-test.js
@@ -11,12 +11,17 @@ const int64 = require('../../../lib/validator/custom-formats/int64')
 const ipv4Address = require('../../../lib/validator/custom-formats/ipv4-address')
 const ipv4Interface = require('../../../lib/validator/custom-formats/ipv4-interface')
 const ipv4Prefix = require('../../../lib/validator/custom-formats/ipv4-prefix')
+const ipv6Address = require('../../../lib/validator/custom-formats/ipv6-address')
+const ipv6Interface = require('../../../lib/validator/custom-formats/ipv6-interface')
+const ipv6Multicast = require('../../../lib/validator/custom-formats/ipv6-multicast')
+const ipv6Prefix = require('../../../lib/validator/custom-formats/ipv6-prefix')
 const netmask = require('../../../lib/validator/custom-formats/netmask')
 const portNumber = require('../../../lib/validator/custom-formats/port-number')
 const time = require('../../../lib/validator/custom-formats/time')
 const uint8 = require('../../../lib/validator/custom-formats/uint8')
 const uint16 = require('../../../lib/validator/custom-formats/uint16')
 const uint32 = require('../../../lib/validator/custom-formats/uint32')
+const uint64 = require('../../../lib/validator/custom-formats/uint64')
 const url = require('../../../lib/validator/custom-formats/url')
 const vlanId = require('../../../lib/validator/custom-formats/vlan-id')
 
@@ -61,6 +66,22 @@ describe('validator/custom-formats', () => {
     expect(customFormats['ipv4-prefix']).to.equal(ipv4Prefix)
   })
 
+  it('includes ipv6-address format', () => {
+    expect(customFormats['ipv6-address']).to.equal(ipv6Address)
+  })
+
+  it('includes ipv6-interface format', () => {
+    expect(customFormats['ipv6-interface']).to.equal(ipv6Interface)
+  })
+
+  it('includes ipv6-multicast format', () => {
+    expect(customFormats['ipv6-multicast']).to.equal(ipv6Multicast)
+  })
+
+  it('includes ipv6-prefix format', () => {
+    expect(customFormats['ipv6-prefix']).to.equal(ipv6Prefix)
+  })
+
   it('includes netmask format', () => {
     expect(customFormats.netmask).to.equal(netmask)
   })
@@ -83,6 +104,10 @@ describe('validator/custom-formats', () => {
 
   it('includes uint32 format', () => {
     expect(customFormats.uint32).to.equal(uint32)
+  })
+
+  it('includes uint64 format', () => {
+    expect(customFormats.uint64).to.equal(uint64)
   })
 
   it('includes url format', () => {

--- a/tests/validator/custom-formats/ipv6-interface-test.js
+++ b/tests/validator/custom-formats/ipv6-interface-test.js
@@ -77,11 +77,11 @@ describe('validator/custom-formats/IPv6-interface', () => {
   })
 
   it('returns true when valid IPv6 interface', () => {
-    expect(ipv6Interface('1080:0:0:0:8:800:200C:417A/32'), 1).to.be.equal(true)
-    expect(ipv6Interface('12AB::CD30/60'), 5).to.be.equal(true)
-    expect(ipv6Interface('12AB::CD3/60'), 6).to.be.equal(true)
-    expect(ipv6Interface('12AB:0:0:CD30:123:4567:89AB:CDEF/60'), 7).to.be.equal(true)
-    expect(ipv6Interface('fe80::6a05:caff:fe05:f789/64'), 8).to.be.equal(true)
-    expect(ipv6Interface('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/68'), 9).to.be.equal(true)
+    expect(ipv6Interface('1080:0:0:0:8:800:200C:417A/32')).to.be.equal(true)
+    expect(ipv6Interface('12AB::CD30/60')).to.be.equal(true)
+    expect(ipv6Interface('12AB::CD3/60')).to.be.equal(true)
+    expect(ipv6Interface('12AB:0:0:CD30:123:4567:89AB:CDEF/60')).to.be.equal(true)
+    expect(ipv6Interface('fe80::6a05:caff:fe05:f789/64')).to.be.equal(true)
+    expect(ipv6Interface('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/68')).to.be.equal(true)
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** code to actually include new IPv6 formats.

