### PR TITLE
DO NOT MERGE – Fix ipv6-interface format

### DIFF
--- a/src/validator/custom-formats/ipv6-interface.js
+++ b/src/validator/custom-formats/ipv6-interface.js
@@ -3,7 +3,7 @@
  */
 
 import ipv6Address from './ipv6-address'
-import {ipv6AddressBits, networkMaskValid} from './utils'
+import {networkMaskValid} from './utils'
 
 /**
  * Validate value as an IPv6 interface
@@ -17,20 +17,9 @@ export default function (value) {
 
   const [ipAddress, networkMask] = value.split('/')
 
-  if (!networkMaskValid(networkMask, true)) {
-    return false
-  }
-
-  if (!ipv6Address(ipAddress)) {
-    return false
-  }
-
-  const bits = ipv6AddressBits(ipAddress)
-  const postPrefixBits = bits.slice(parseInt(networkMask, 10))
-
-  if (networkMask === '128') {
-    return false
-  }
-
-  return !/^(0+|1+)$/.test(postPrefixBits)
+  return (
+    ipv6Address(ipAddress) &&
+    networkMaskValid(networkMask, true) &&
+    networkMask !== '128'
+  )
 }

--- a/tests/validator/custom-formats/ipv6-interface-test.js
+++ b/tests/validator/custom-formats/ipv6-interface-test.js
@@ -83,5 +83,8 @@ describe('validator/custom-formats/IPv6-interface', () => {
     expect(ipv6Interface('12AB:0:0:CD30:123:4567:89AB:CDEF/60')).to.be.equal(true)
     expect(ipv6Interface('fe80::6a05:caff:fe05:f789/64')).to.be.equal(true)
     expect(ipv6Interface('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/68')).to.be.equal(true)
+    expect(ipv6Interface('12AB:0000:0000:CD30:0000:0000:0000:0000/60')).to.be.equal(true)
+    expect(ipv6Interface('12AB::CD30:0:0:0:0/60')).to.be.equal(true)
+    expect(ipv6Interface('12AB:0:0:CD30::/60')).to.be.equal(true)
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `ipv6-interface` format to not deny host of all one bits or zero bits.

