### PR TITLE
Expose more methods via index

### DIFF
--- a/src/conversion/index.js
+++ b/src/conversion/index.js
@@ -1,0 +1,2 @@
+export {default as normalizeView} from './normalize-view'
+export {default as viewV1ToV2} from './view-v1-to-v2'

--- a/src/generator.js
+++ b/src/generator.js
@@ -140,7 +140,7 @@ function addDependentModel (propertyName, dependencyName, model, children, cellD
  * @param {BunsenModel} schema - the schema to generate a default view for
  * @returns {BunsenView} the generated view
  */
-export function getDefaultView (schema) {
+export function generateView (schema) {
   const model = dereference(schema || {}).schema
 
   const view = {
@@ -161,3 +161,5 @@ export function getDefaultView (schema) {
 
   return view
 }
+
+export default generateView

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,39 @@
+import './typedefs'
+
+import {
+  CHANGE_MODEL,
+  changeModel,
+  CHANGE_VALUE,
+  changeValue,
+  updateValidationResults,
+  validate,
+  VALIDATION_RESOLVED
+} from './actions'
+
+export const actions = {
+  CHANGE_MODEL,
+  changeModel,
+  CHANGE_VALUE,
+  changeValue,
+  updateValidationResults,
+  validate,
+  VALIDATION_RESOLVED
+}
+
+import {
+  computePatch,
+  getChangeSet,
+  traverseObjectLeaf
+} from './change-utils'
+
+export const changeUtils = {
+  computePatch,
+  getChangeSet,
+  traverseObjectLeaf
+}
+
+export {normalizeView, viewV1ToV2} from './conversion'
+
 import {
   dereference as _dereference,
   dereferenceSubSchema,
@@ -13,6 +49,9 @@ export const dereference = {
   processRef,
   recurse
 }
+
+export {default as generateView} from './generator'
+export {default as reducer} from './reducer'
 
 import {
   doesModelContainRequiredField,
@@ -38,4 +77,5 @@ export const utils = {
   populateQuery
 }
 
-export {default as validator} from './validator'
+export {default as validateView, validateModel} from './validator'
+export {getCellDefaults} from './validator/defaults'

--- a/tests/generator-test.js
+++ b/tests/generator-test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect
-var getDefaultView = require('../lib/generator').getDefaultView
+var generateView = require('../lib/generator').generateView
 var validator = require('../lib/validator')
 
 var simpleModel = require('./fixtures/simple-model')
@@ -10,11 +10,11 @@ var dependenciesModel = require('./fixtures/dependencies-model')
 var dependenciesView = require('./fixtures/dependencies-view')
 
 describe('generator', function () {
-  describe('getDefaultView()', function () {
+  describe('generateView()', function () {
     var result
     describe('simple schema', function () {
       beforeEach(() => {
-        result = getDefaultView(simpleModel)
+        result = generateView(simpleModel)
       })
 
       it('creates proper simple layout', function () {
@@ -24,7 +24,7 @@ describe('generator', function () {
 
     describe('array schema', function () {
       beforeEach(() => {
-        result = getDefaultView(arrayModel)
+        result = generateView(arrayModel)
       })
 
       it('creates proper array layout', function () {
@@ -34,7 +34,7 @@ describe('generator', function () {
 
     describe('dependencies schema', function () {
       beforeEach(() => {
-        result = getDefaultView(dependenciesModel)
+        result = generateView(dependenciesModel)
       })
 
       it('creates proper dependencies layout', function () {
@@ -78,7 +78,7 @@ describe('generator', function () {
           type: 'object'
         }
 
-        view = getDefaultView(model)
+        view = generateView(model)
       })
 
       it('generates valid view view', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** more method exports to `index.js`.
* **Renamed** `getDefaultView()` to `generateView()`.

