### PR TITLE
Keep required objects

### DIFF
--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -257,6 +257,21 @@ describe('validate action', function () {
     expect(defaultValue).to.eql({})
   })
 
+  it('initializes required objects', function () {
+    var model = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'object'
+        }
+      },
+      required: ['foo']
+    }
+
+    var defaultValue = getDefaultValue(null, {}, model)
+    expect(defaultValue).to.eql({foo: {}})
+  })
+
   function getState () {
     return {
       get value () {

--- a/tests/reducer-test.js
+++ b/tests/reducer-test.js
@@ -5,6 +5,8 @@ var actions = require('../lib/actions')
 var actionReducers = reducerExports.actionReducers
 var reducer = reducerExports.reducer
 
+var REDUX_INIT = '@@redux/INIT'
+
 describe('reducer', function () {
   var sandbox
 
@@ -18,7 +20,7 @@ describe('reducer', function () {
   })
 
   ;[
-    '@@redux/INIT',
+    REDUX_INIT,
     actions.CHANGE_MODEL,
     actions.CHANGE_VALUE,
     actions.VALIDATION_RESOLVED
@@ -83,11 +85,15 @@ describe('reducer', function () {
 
   describe('initial state', function () {
     it('should be what we want', function () {
-      var initialState = reducer({}, {type: '@@redux/INIT'})
+      var initialState = reducer({}, {type: REDUX_INIT})
 
       expect(initialState.errors).to.eql({})
       expect(initialState.validationResult).to.eql({warnings: [], errors: []})
       expect(initialState.value).to.eql(null)
+    })
+
+    it('does not remove required arrays', function () {
+
     })
   })
 
@@ -186,6 +192,79 @@ describe('reducer', function () {
 
       var changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: newValue, bunsenId: null})
       expect(changedState.value).to.eql({a: {b1: [{c1: {}}, {c2: 12}, {c3: [1, 2, 3]}]}})
+    })
+
+    it('does not remove required properties from an object', function () {
+      var initialState = {
+        errors: {},
+        validationResult: {warnings: [], errors: []},
+        value: {
+          foo: {
+            bar: 'baz'
+          }
+        },
+        baseModel: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'object'
+            }
+          },
+          required: ['foo']
+        }
+      }
+
+      var storedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: {foo: {}}, bunsenId: null})
+      expect(storedState.value).to.eql({foo: {}})
+    })
+
+    it('preserves empty objects that are required', function () {
+      var initialState = {
+        errors: {},
+        validationResult: {warnings: [], errors: []},
+        value: {
+          foo: {
+            fooProp: ''
+          }
+        },
+        baseModel: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'object'
+            }
+          },
+          required: ['foo']
+        }
+      }
+
+      var changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: {}, bunsenId: 'foo'})
+      expect(changedState.value).to.eql({foo: {}})
+    })
+
+    it('preserves empty arrays that are required', function () {
+      var model = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'array'
+          }
+        },
+        required: ['foo']
+      }
+
+      var initialState = {
+        errors: {},
+        validationResult: {warnings: [], errors: []},
+        value: {
+          foo: ['foo item']
+        },
+        baseModel: model,
+        model
+      }
+
+      var changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: [], bunsenId: 'foo'})
+      expect(changedState.value).to.eql({foo: []})
     })
   })
 

--- a/tests/reducer-test.js
+++ b/tests/reducer-test.js
@@ -148,11 +148,42 @@ describe('reducer', function () {
     })
 
     it('will prune all the dead wood when setting root object', function () {
+      var model = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'object',
+                properties: {
+                  baz: {
+                    type: 'null'
+                  },
+                  qux: {
+                    type: 'number'
+                  }
+                }
+              },
+              waldo: {
+                type: 'null'
+              },
+              buzz: {
+                type: 'boolean'
+              },
+              fizz: {
+                type: 'boolean'
+              }
+            }
+          }
+        }
+      }
       var initialState = {
         errors: {},
         validationResult: {warnings: [], errors: []},
         value: null,
-        baseModel: {}
+        baseModel: model,
+        model
       }
       var newValue = {
         foo: {
@@ -171,11 +202,28 @@ describe('reducer', function () {
     })
 
     it('will prune all the dead wood out of a complex array', function () {
+      var model = {
+        type: 'object',
+        properties: {
+          a: {
+            type: 'object',
+            properties: {
+              b1: {
+                type: 'array'
+              },
+              b2: {
+                type: 'array'
+              }
+            }
+          }
+        }
+      }
       var initialState = {
         errors: {},
         validationResult: {warnings: [], errors: []},
         value: null,
-        baseModel: {}
+        baseModel: model,
+        model
       }
       var newValue = {
         a: {
@@ -195,6 +243,16 @@ describe('reducer', function () {
     })
 
     it('does not remove required properties from an object', function () {
+      var model = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'object'
+          }
+        },
+        required: ['foo']
+      }
+
       var initialState = {
         errors: {},
         validationResult: {warnings: [], errors: []},
@@ -203,15 +261,8 @@ describe('reducer', function () {
             bar: 'baz'
           }
         },
-        baseModel: {
-          type: 'object',
-          properties: {
-            foo: {
-              type: 'object'
-            }
-          },
-          required: ['foo']
-        }
+        baseModel: model,
+        model
       }
 
       var storedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: {foo: {}}, bunsenId: null})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**Changed** empty object/array clearing to leave empty objects/arrays that are required properties of a parent object.