### PR TITLE
0.19.x - Keep required objects

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -30,6 +30,32 @@ function immutableOnce (object) {
     immutableObject = immutable(object)
   }
   return immutableObject
+
+}
+function isArrayItem (segment) {
+  return /^\d+$/.test(segment)
+}
+
+function subModel (model, modelPath) {
+  if (modelPath.length <= 0) {
+    return model
+  }
+  const pathSeg = modelPath.pop()
+  if (isArrayItem(pathSeg)) {
+    return subModel(model, modelPath.items)
+  }
+  return subModel(model.properties[pathSeg], pathSeg)
+}
+
+function isRequired (model, id) {
+  if (id === null) {
+    return false
+  }
+  const modelPath = id.split('.')
+  const lastSegment = modelPath.pop()
+  modelPath.reverse()
+  const parentModel = subModel(model, modelPath)
+  return _.includes(parentModel.required, lastSegment)
 }
 
 /**
@@ -37,18 +63,16 @@ function immutableOnce (object) {
  * @param {Object} value - our current value POJO
  * @returns {Object} a value cleaned of any `null`s
  */
-function recursiveClean (value) {
-  let output = {}
-  if (Array.isArray(value)) {
-    output = []
-  }
+function recursiveClean (value, model) {
+  let output = Array.isArray(value) ? [] : {}
   _.forEach(value, (subValue, key) => {
-    if (!_.isEmpty(subValue) || _.isNumber(subValue) || typeof subValue === 'boolean' || subValue instanceof Boolean) {
-      if (_.isObject(subValue) || Array.isArray(subValue)) {
-        output[key] = recursiveClean(subValue)
-      } else {
-        output[key] = subValue
-      }
+    const notEmpty = !_.isEmpty(subValue)
+    if (Array.isArray(subValue) && (notEmpty || _.includes(_.get(model, 'required'), key))) {
+      output[key] = recursiveClean(subValue, _.get(model, 'items'))
+    } else if (_.isObject(subValue) && (notEmpty || _.includes(_.get(model, 'required'), key))) {
+      output[key] = recursiveClean(subValue, _.get(model, 'properties.' + key))
+    } else if (notEmpty || _.isNumber(subValue) || typeof subValue === 'boolean' || subValue instanceof Boolean) {
+      output[key] = subValue
     }
   })
   return output
@@ -66,7 +90,7 @@ export const actionReducers = {
     if (state && state.baseModel) {
       let initialValue = state.value || {}
       state.baseModel = getDereferencedModelSchema(state.baseModel)
-      state.model = evaluateConditions(_.cloneDeep(state.baseModel), recursiveClean(initialValue))
+      state.model = evaluateConditions(_.cloneDeep(state.baseModel), recursiveClean(initialValue, state.baseModel))
       // leave this undefined to force consumers to go through the proper CHANGE_VALUE channel
       // for value changes
       state.value = undefined
@@ -106,7 +130,7 @@ export const actionReducers = {
 
     if (bunsenId === null) {
       valueChangeSet = getChangeSet(state.value, value)
-      newValue = immutableOnce(recursiveClean(value))
+      newValue = immutableOnce(recursiveClean(value, state.model))
     } else {
       newValue = immutableOnce(state.value)
       const segments = bunsenId.split('.')
@@ -130,20 +154,21 @@ export const actionReducers = {
           })
           newValue = set(newValue, bunsenId, value)
         }
-      } else if (_.includes([null, ''], value) || (Array.isArray(value) && value.length === 0)) {
+      } else if (
+        _.includes([null, ''], value) ||
+        (Array.isArray(value) && value.length === 0 && !isRequired(state.model, bunsenId))
+      ) {
         valueChangeSet.set(bunsenId, {
           value,
           type: 'unset'
         })
         newValue = unset(newValue, bunsenId)
-      } else {
-        if (!_.isEqual(value, _.get(newValue, bunsenId))) {
-          valueChangeSet.set(bunsenId, {
-            value,
-            type: 'set'
-          })
-          newValue = set(newValue, bunsenId, value)
-        }
+      } else if (!_.isEqual(value, _.get(newValue, bunsenId))) {
+        valueChangeSet.set(bunsenId, {
+          value,
+          type: 'set'
+        })
+        newValue = set(newValue, bunsenId, value)
       }
     }
 

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -257,6 +257,21 @@ describe('validate action', function () {
     expect(defaultValue).to.eql({})
   })
 
+  it('initializes required objects', function () {
+    var model = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'object'
+        }
+      },
+      required: ['foo']
+    }
+
+    var defaultValue = getDefaultValue(null, {}, model)
+    expect(defaultValue).to.eql({foo: {}})
+  })
+
   function getState () {
     return {
       get value () {

--- a/tests/reducer-test.js
+++ b/tests/reducer-test.js
@@ -142,11 +142,42 @@ describe('reducer', function () {
     })
 
     it('will prune all the dead wood when setting root object', function () {
+      var model = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'object',
+                properties: {
+                  baz: {
+                    type: 'null'
+                  },
+                  qux: {
+                    type: 'number'
+                  }
+                }
+              },
+              waldo: {
+                type: 'null'
+              },
+              buzz: {
+                type: 'boolean'
+              },
+              fizz: {
+                type: 'boolean'
+              }
+            }
+          }
+        }
+      }
       var initialState = {
         errors: {},
         validationResult: {warnings: [], errors: []},
         value: null,
-        baseModel: {}
+        baseModel: model,
+        model
       }
       var newValue = {
         foo: {
@@ -165,11 +196,28 @@ describe('reducer', function () {
     })
 
     it('will prune all the dead wood out of a complex array', function () {
+      var model = {
+        type: 'object',
+        properties: {
+          a: {
+            type: 'object',
+            properties: {
+              b1: {
+                type: 'array'
+              },
+              b2: {
+                type: 'array'
+              }
+            }
+          }
+        }
+      }
       var initialState = {
         errors: {},
         validationResult: {warnings: [], errors: []},
         value: null,
-        baseModel: {}
+        baseModel: model,
+        model
       }
       var newValue = {
         a: {
@@ -186,6 +234,82 @@ describe('reducer', function () {
 
       var changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: newValue, bunsenId: null})
       expect(changedState.value).to.eql({a: {b1: [{c1: {}}, {c2: 12}, {c3: [1, 2, 3]}]}})
+    })
+
+    it('does not remove required properties from an object', function () {
+      var model = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'object'
+          }
+        },
+        required: ['foo']
+      }
+
+      var initialState = {
+        errors: {},
+        validationResult: {warnings: [], errors: []},
+        value: {
+          foo: {
+            bar: 'baz'
+          }
+        },
+        baseModel: model,
+        model
+      }
+
+      var storedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: {foo: {}}, bunsenId: null})
+      expect(storedState.value).to.eql({foo: {}})
+    })
+
+    it('preserves empty objects that are required', function () {
+      var initialState = {
+        errors: {},
+        validationResult: {warnings: [], errors: []},
+        value: {
+          foo: {
+            fooProp: ''
+          }
+        },
+        baseModel: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'object'
+            }
+          },
+          required: ['foo']
+        }
+      }
+
+      var changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: {}, bunsenId: 'foo'})
+      expect(changedState.value).to.eql({foo: {}})
+    })
+
+    it('preserves empty arrays that are required', function () {
+      var model = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'array'
+          }
+        },
+        required: ['foo']
+      }
+
+      var initialState = {
+        errors: {},
+        validationResult: {warnings: [], errors: []},
+        value: {
+          foo: ['foo item']
+        },
+        baseModel: model,
+        model
+      }
+
+      var changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: [], bunsenId: 'foo'})
+      expect(changedState.value).to.eql({foo: []})
     })
   })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**Changed** empty object/array clearing to leave empty objects/arrays that are required properties of a parent object.