### PR TITLE
Added queryForCurrentValue to select renderer options

### DIFF
--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -453,6 +453,11 @@ export default {
               type: 'object'
             },
 
+            // whether or not to try to query for the current value when Ember Data is used to populate options
+            queryForCurrentValue: {
+              type: 'boolean'
+            },
+
             // description: where in API response to find records for list-based inputs
             recordsPath: {
               type: 'string'


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* Added queryForCurrentValue to select renderer options schema
