### PR TITLE
Support spread/passthrough options on renderers

### DIFF
--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -218,7 +218,7 @@ export default {
             {'$ref': '#/definitions/linkRenderer'},
             {'$ref': '#/definitions/numberRenderer'},
             {'$ref': '#/definitions/passwordRenderer'},
-            {'$ref': '#/definitions/selectRenderer'},
+            {'$ref': '#/definitions/'},
             {'$ref': '#/definitions/stringRenderer'},
             {'$ref': '#/definitions/textareaRenderer'},
             {'$ref': '#/definitions/urlRenderer'}
@@ -450,6 +450,82 @@ export default {
 
         options: {
           additionalProperties: true,
+          properties: {
+            // the attribute for specifying data to populate the list with
+            data: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  label: {
+                    type: 'string'
+                  },
+                  value: {
+                    type: ['string', 'number', 'integer', 'boolean', 'object']
+                  }
+                }
+              }
+            },
+
+            // description: the API endpoint for list-based inputs
+            endpoint: {
+              type: 'string'
+            },
+
+            // the attribute to enable local filtering
+            localFiltering: {
+              type: 'boolean'
+            },
+
+            // the attribute of the listed items to use as a label
+            labelAttribute: {
+              type: 'string'
+            },
+
+            // description: the type of model to fetch for list-based inputs
+            modelType: {
+              type: 'string'
+            },
+
+            // specifies if none should be available as an option
+            none: {
+              type: 'object',
+              properties: {
+                label: {
+                  type: 'string'
+                },
+                present: {
+                  type: 'boolean'
+                },
+                value: {
+                  type: ['string', 'number', 'integer', 'boolean', 'object']
+                }
+              }
+            },
+
+            // description: a hash of key/value pairs to use as query string to fetch values for list-based inputs
+            query: {
+              additionalProperties: {
+                type: 'string'
+              },
+              type: 'object'
+            },
+
+            // whether or not to try to query for the current value when Ember Data is used to populate options
+            queryForCurrentValue: {
+              type: 'boolean'
+            },
+
+            // description: where in API response to find records for list-based inputs
+            recordsPath: {
+              type: 'string'
+            },
+
+            // the attribute of the listed items to use as a value
+            valueAttribute: {
+              type: 'string'
+            }
+          },
           type: 'object'
         },
 

--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -48,9 +48,12 @@ export default {
         name: {
           enum: ['boolean'],
           type: 'string'
-        }
+        },
 
-        // no options yet
+        options: {
+          additionalProperties: true,
+          type: 'object'
+        }
       },
       type: 'object'
     },
@@ -63,6 +66,11 @@ export default {
         name: {
           enum: ['button-group'],
           type: 'string'
+        },
+
+        options: {
+          additionalProperties: true,
+          type: 'object'
         },
 
         // Size of buttons (small, large, etc)
@@ -255,6 +263,11 @@ export default {
           }
         },
 
+        options: {
+          additionalProperties: true,
+          type: 'object'
+        },
+
         // Size of buttons (small, large, etc)
         size: {
           type: 'string'
@@ -323,6 +336,11 @@ export default {
           type: 'string'
         },
 
+        options: {
+          additionalProperties: true,
+          type: 'object'
+        },
+
         // named route to use for link
         route: {
           type: 'string'
@@ -344,9 +362,12 @@ export default {
         name: {
           enum: ['number'],
           type: 'string'
-        }
+        },
 
-        // no options yet
+        options: {
+          additionalProperties: true,
+          type: 'object'
+        }
       },
       type: 'object'
     },
@@ -371,9 +392,12 @@ export default {
         name: {
           enum: ['password'],
           type: 'string'
-        }
+        },
 
-        // no options yet
+        options: {
+          additionalProperties: true,
+          type: 'object'
+        }
       },
       type: 'object'
     },
@@ -382,6 +406,41 @@ export default {
     selectRenderer: {
       additionalProperties: false,
       properties: {
+        // the attribute for specifying data to populate the list with
+        data: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              label: {
+                type: 'string'
+              },
+              value: {
+                type: ['string', 'number', 'integer', 'boolean', 'object']
+              }
+            }
+          }
+        },
+
+        // description: the API endpoint for list-based inputs
+        endpoint: {
+          type: 'string'
+        },
+
+        // the attribute to enable local filtering
+        localFiltering: {
+          type: 'boolean'
+        },
+
+        // the attribute of the listed items to use as a label
+        labelAttribute: {
+          type: 'string'
+        },
+
+        // description: the type of model to fetch for list-based inputs
+        modelType: {
+          type: 'string'
+        },
 
         // the only valid names for a select are 'select' and 'multi-select'
         name: {
@@ -389,86 +448,48 @@ export default {
           type: 'string'
         },
 
-        // the options specific to a select renderer
         options: {
-          additionalProperties: false,
+          additionalProperties: true,
+          type: 'object'
+        },
+
+        // specifies if none should be available as an option
+        none: {
+          type: 'object',
           properties: {
-            // the attribute for specifying data to populate the list with
-            data: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  label: {
-                    type: 'string'
-                  },
-                  value: {
-                    type: ['string', 'number', 'integer', 'boolean', 'object']
-                  }
-                }
-              }
-            },
-
-            // description: the API endpoint for list-based inputs
-            endpoint: {
+            label: {
               type: 'string'
             },
-
-            // the attribute to enable local filtering
-            localFiltering: {
+            present: {
               type: 'boolean'
             },
-
-            // the attribute of the listed items to use as a label
-            labelAttribute: {
-              type: 'string'
-            },
-
-            // description: the type of model to fetch for list-based inputs
-            modelType: {
-              type: 'string'
-            },
-
-            // specifies if none should be available as an option
-            none: {
-              type: 'object',
-              properties: {
-                label: {
-                  type: 'string'
-                },
-                present: {
-                  type: 'boolean'
-                },
-                value: {
-                  type: ['string', 'number', 'integer', 'boolean', 'object']
-                }
-              }
-            },
-
-            // description: a hash of key/value pairs to use as query string to fetch values for list-based inputs
-            query: {
-              additionalProperties: {
-                type: 'string'
-              },
-              type: 'object'
-            },
-
-            // whether or not to try to query for the current value when Ember Data is used to populate options
-            queryForCurrentValue: {
-              type: 'boolean'
-            },
-
-            // description: where in API response to find records for list-based inputs
-            recordsPath: {
-              type: 'string'
-            },
-
-            // the attribute of the listed items to use as a value
-            valueAttribute: {
-              type: 'string'
+            value: {
+              type: ['string', 'number', 'integer', 'boolean', 'object']
             }
+          }
+        },
+
+        // description: a hash of key/value pairs to use as query string to fetch values for list-based inputs
+        query: {
+          additionalProperties: {
+            type: 'string'
           },
           type: 'object'
+        },
+
+        // whether or not to try to query for the current value when Ember Data is used to populate options
+        queryForCurrentValue: {
+          type: 'boolean'
+        },
+
+        // description: where in API response to find records for list-based inputs
+        recordsPath: {
+          type: 'string'
+        },
+
+        // the attribute of the listed items to use as a value
+        valueAttribute: {
+          type: 'string'
         }
       },
       type: 'object'
@@ -482,6 +503,11 @@ export default {
         name: {
           enum: ['string'],
           type: 'string'
+        },
+
+        options: {
+          additionalProperties: true,
+          type: 'object'
         },
 
         // Input type (text, password, datetime, etc)
@@ -519,6 +545,11 @@ export default {
           type: 'string'
         },
 
+        options: {
+          additionalProperties: true,
+          type: 'object'
+        },
+
         rows: {
           type: 'integer'
         }
@@ -549,9 +580,12 @@ export default {
         name: {
           enum: ['url'],
           type: 'string'
-        }
+        },
 
-        // no options yet
+        options: {
+          additionalProperties: true,
+          type: 'object'
+        }
       },
       type: 'object'
     }

--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -218,7 +218,7 @@ export default {
             {'$ref': '#/definitions/linkRenderer'},
             {'$ref': '#/definitions/numberRenderer'},
             {'$ref': '#/definitions/passwordRenderer'},
-            {'$ref': '#/definitions/'},
+            {'$ref': '#/definitions/selectRenderer'},
             {'$ref': '#/definitions/stringRenderer'},
             {'$ref': '#/definitions/textareaRenderer'},
             {'$ref': '#/definitions/urlRenderer'}

--- a/tests/validator/view-schema/v2-test.js
+++ b/tests/validator/view-schema/v2-test.js
@@ -22,18 +22,16 @@ describe('v2 schema validation', () => {
           {
             model: 'foo',
             renderer: {
-              name: 'select',
-              options: {
-                data: [{
-                  label: 'label',
-                  value: 'value'
-                }],
-                none: {
-                  label: 'None',
-                  present: true,
-                  value: ''
-                }
-              }
+              data: [{
+                label: 'label',
+                value: 'value'
+              }],
+              none: {
+                label: 'None',
+                present: true,
+                value: ''
+              },
+              name: 'select'
             }
           }
         ]
@@ -46,30 +44,30 @@ describe('v2 schema validation', () => {
       })
 
       it('passes validation when value is number', function () {
-        value.cells[0].renderer.options.data[0].value = 1.1
+        value.cells[0].renderer.data[0].value = 1.1
         expect(schemaValidator.validate(value, model)).to.equal(true)
       })
 
       it('passes validation when value is integer', function () {
-        value.cells[0].renderer.options.data[0].value = 1
+        value.cells[0].renderer.data[0].value = 1
         expect(schemaValidator.validate(value, model)).to.equal(true)
       })
       it('passes validation when value is boolean', function () {
-        value.cells[0].renderer.options.data[0].value = true
+        value.cells[0].renderer.data[0].value = true
         expect(schemaValidator.validate(value, model)).to.equal(true)
       })
       it('passes validation when value is object', function () {
-        value.cells[0].renderer.options.data[0].value = {}
+        value.cells[0].renderer.data[0].value = {}
         expect(schemaValidator.validate(value, model)).to.equal(true)
       })
 
       it('fails validation when value is an array', function () {
-        value.cells[0].renderer.options.data[0].value = []
+        value.cells[0].renderer.data[0].value = []
         expect(schemaValidator.validate(value, model)).to.equal(false)
       })
 
       it('fails validation when value is null', function () {
-        value.cells[0].renderer.options.data[0].value = null
+        value.cells[0].renderer.data[0].value = null
         expect(schemaValidator.validate(value, model)).to.equal(false)
       })
     })
@@ -80,30 +78,30 @@ describe('v2 schema validation', () => {
       })
 
       it('passes validation when value is number', function () {
-        value.cells[0].renderer.options.none.value = 1.1
+        value.cells[0].renderer.none.value = 1.1
         expect(schemaValidator.validate(value, model)).to.equal(true)
       })
 
       it('passes validation when value is integer', function () {
-        value.cells[0].renderer.options.none.value = 1
+        value.cells[0].renderer.none.value = 1
         expect(schemaValidator.validate(value, model)).to.equal(true)
       })
       it('passes validation when value is boolean', function () {
-        value.cells[0].renderer.options.none.value = true
+        value.cells[0].renderer.none.value = true
         expect(schemaValidator.validate(value, model)).to.equal(true)
       })
       it('passes validation when value is object', function () {
-        value.cells[0].renderer.options.none.value = {}
+        value.cells[0].renderer.none.value = {}
         expect(schemaValidator.validate(value, model)).to.equal(true)
       })
 
       it('fails validation when value is an array', function () {
-        value.cells[0].renderer.options.none.value = []
+        value.cells[0].renderer.none.value = []
         expect(schemaValidator.validate(value, model)).to.equal(false)
       })
 
       it('fails validation when value is null', function () {
-        value.cells[0].renderer.options.none.value = null
+        value.cells[0].renderer.none.value = null
         expect(schemaValidator.validate(value, model)).to.equal(false)
       })
     })

--- a/tests/validator/view-schema/v2-test.js
+++ b/tests/validator/view-schema/v2-test.js
@@ -13,96 +13,195 @@ describe('v2 schema validation', () => {
   })
 
   describe('selectRenderer', function () {
-    let value
-    beforeEach(function () {
-      value = {
-        type: 'form',
-        version: '2.0',
-        cells: [
-          {
-            model: 'foo',
-            renderer: {
-              data: [{
-                label: 'label',
-                value: 'value'
-              }],
-              none: {
-                label: 'None',
-                present: true,
-                value: ''
-              },
-              name: 'select'
+    describe('when properties set directly on renderer', function () {
+      let value
+      beforeEach(function () {
+        value = {
+          type: 'form',
+          version: '2.0',
+          cells: [
+            {
+              model: 'foo',
+              renderer: {
+                data: [{
+                  label: 'label',
+                  value: 'value'
+                }],
+                none: {
+                  label: 'None',
+                  present: true,
+                  value: ''
+                },
+                name: 'select'
+              }
             }
-          }
-        ]
-      }
+          ]
+        }
+      })
+
+      describe('when data value is specified', function () {
+        it('passes validation when value is string', function () {
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('passes validation when value is number', function () {
+          value.cells[0].renderer.data[0].value = 1.1
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('passes validation when value is integer', function () {
+          value.cells[0].renderer.data[0].value = 1
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+        it('passes validation when value is boolean', function () {
+          value.cells[0].renderer.data[0].value = true
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+        it('passes validation when value is object', function () {
+          value.cells[0].renderer.data[0].value = {}
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('fails validation when value is an array', function () {
+          value.cells[0].renderer.data[0].value = []
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is null', function () {
+          value.cells[0].renderer.data[0].value = null
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+      })
+
+      describe('when none value is specified', function () {
+        it('passes validation when value is string', function () {
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('passes validation when value is number', function () {
+          value.cells[0].renderer.none.value = 1.1
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('passes validation when value is integer', function () {
+          value.cells[0].renderer.none.value = 1
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+        it('passes validation when value is boolean', function () {
+          value.cells[0].renderer.none.value = true
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+        it('passes validation when value is object', function () {
+          value.cells[0].renderer.none.value = {}
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('fails validation when value is an array', function () {
+          value.cells[0].renderer.none.value = []
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is null', function () {
+          value.cells[0].renderer.none.value = null
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+      })
     })
 
-    describe('when data value is specified', function () {
-      it('passes validation when value is string', function () {
-        expect(schemaValidator.validate(value, model)).to.equal(true)
+    describe('when properties set on renderer.options', function () {
+      let value
+      beforeEach(function () {
+        value = {
+          type: 'form',
+          version: '2.0',
+          cells: [
+            {
+              model: 'foo',
+              renderer: {
+                name: 'select',
+                options: {
+                  data: [{
+                    label: 'label',
+                    value: 'value'
+                  }],
+                  none: {
+                    label: 'None',
+                    present: true,
+                    value: ''
+                  }
+                }
+              }
+            }
+          ]
+        }
       })
 
-      it('passes validation when value is number', function () {
-        value.cells[0].renderer.data[0].value = 1.1
-        expect(schemaValidator.validate(value, model)).to.equal(true)
+      describe('when data value is specified', function () {
+        it('passes validation when value is string', function () {
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('passes validation when value is number', function () {
+          value.cells[0].renderer.options.data[0].value = 1.1
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('passes validation when value is integer', function () {
+          value.cells[0].renderer.options.data[0].value = 1
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+        it('passes validation when value is boolean', function () {
+          value.cells[0].renderer.options.data[0].value = true
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+        it('passes validation when value is object', function () {
+          value.cells[0].renderer.options.data[0].value = {}
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('fails validation when value is an array', function () {
+          value.cells[0].renderer.options.data[0].value = []
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is null', function () {
+          value.cells[0].renderer.options.data[0].value = null
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
       })
 
-      it('passes validation when value is integer', function () {
-        value.cells[0].renderer.data[0].value = 1
-        expect(schemaValidator.validate(value, model)).to.equal(true)
-      })
-      it('passes validation when value is boolean', function () {
-        value.cells[0].renderer.data[0].value = true
-        expect(schemaValidator.validate(value, model)).to.equal(true)
-      })
-      it('passes validation when value is object', function () {
-        value.cells[0].renderer.data[0].value = {}
-        expect(schemaValidator.validate(value, model)).to.equal(true)
-      })
+      describe('when none value is specified', function () {
+        it('passes validation when value is string', function () {
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
 
-      it('fails validation when value is an array', function () {
-        value.cells[0].renderer.data[0].value = []
-        expect(schemaValidator.validate(value, model)).to.equal(false)
-      })
+        it('passes validation when value is number', function () {
+          value.cells[0].renderer.options.none.value = 1.1
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
 
-      it('fails validation when value is null', function () {
-        value.cells[0].renderer.data[0].value = null
-        expect(schemaValidator.validate(value, model)).to.equal(false)
-      })
-    })
+        it('passes validation when value is integer', function () {
+          value.cells[0].renderer.options.none.value = 1
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+        it('passes validation when value is boolean', function () {
+          value.cells[0].renderer.options.none.value = true
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+        it('passes validation when value is object', function () {
+          value.cells[0].renderer.options.none.value = {}
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
 
-    describe('when none value is specified', function () {
-      it('passes validation when value is string', function () {
-        expect(schemaValidator.validate(value, model)).to.equal(true)
-      })
+        it('fails validation when value is an array', function () {
+          value.cells[0].renderer.options.none.value = []
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
 
-      it('passes validation when value is number', function () {
-        value.cells[0].renderer.none.value = 1.1
-        expect(schemaValidator.validate(value, model)).to.equal(true)
-      })
-
-      it('passes validation when value is integer', function () {
-        value.cells[0].renderer.none.value = 1
-        expect(schemaValidator.validate(value, model)).to.equal(true)
-      })
-      it('passes validation when value is boolean', function () {
-        value.cells[0].renderer.none.value = true
-        expect(schemaValidator.validate(value, model)).to.equal(true)
-      })
-      it('passes validation when value is object', function () {
-        value.cells[0].renderer.none.value = {}
-        expect(schemaValidator.validate(value, model)).to.equal(true)
-      })
-
-      it('fails validation when value is an array', function () {
-        value.cells[0].renderer.none.value = []
-        expect(schemaValidator.validate(value, model)).to.equal(false)
-      })
-
-      it('fails validation when value is null', function () {
-        value.cells[0].renderer.none.value = null
-        expect(schemaValidator.validate(value, model)).to.equal(false)
+        it('fails validation when value is null', function () {
+          value.cells[0].renderer.options.none.value = null
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
       })
     })
   })

--- a/tests/validator/view-schema/v2-test.js
+++ b/tests/validator/view-schema/v2-test.js
@@ -53,10 +53,12 @@ describe('v2 schema validation', () => {
           value.cells[0].renderer.data[0].value = 1
           expect(schemaValidator.validate(value, model)).to.equal(true)
         })
+
         it('passes validation when value is boolean', function () {
           value.cells[0].renderer.data[0].value = true
           expect(schemaValidator.validate(value, model)).to.equal(true)
         })
+
         it('passes validation when value is object', function () {
           value.cells[0].renderer.data[0].value = {}
           expect(schemaValidator.validate(value, model)).to.equal(true)
@@ -87,10 +89,12 @@ describe('v2 schema validation', () => {
           value.cells[0].renderer.none.value = 1
           expect(schemaValidator.validate(value, model)).to.equal(true)
         })
+
         it('passes validation when value is boolean', function () {
           value.cells[0].renderer.none.value = true
           expect(schemaValidator.validate(value, model)).to.equal(true)
         })
+
         it('passes validation when value is object', function () {
           value.cells[0].renderer.none.value = {}
           expect(schemaValidator.validate(value, model)).to.equal(true)
@@ -150,10 +154,12 @@ describe('v2 schema validation', () => {
           value.cells[0].renderer.options.data[0].value = 1
           expect(schemaValidator.validate(value, model)).to.equal(true)
         })
+
         it('passes validation when value is boolean', function () {
           value.cells[0].renderer.options.data[0].value = true
           expect(schemaValidator.validate(value, model)).to.equal(true)
         })
+
         it('passes validation when value is object', function () {
           value.cells[0].renderer.options.data[0].value = {}
           expect(schemaValidator.validate(value, model)).to.equal(true)
@@ -184,10 +190,12 @@ describe('v2 schema validation', () => {
           value.cells[0].renderer.options.none.value = 1
           expect(schemaValidator.validate(value, model)).to.equal(true)
         })
+
         it('passes validation when value is boolean', function () {
           value.cells[0].renderer.options.none.value = true
           expect(schemaValidator.validate(value, model)).to.equal(true)
         })
+
         it('passes validation when value is object', function () {
           value.cells[0].renderer.options.none.value = {}
           expect(schemaValidator.validate(value, model)).to.equal(true)


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** support for passthrough options (spread options). This allows new properties of downstream to be leveraged as soon as they are available, with the downside of them not being validated at the bunsen level.
