### PR TITLE
Added "unless" functionality to model conditionals

### DIFF
--- a/tests/evaluate-conditions-test.js
+++ b/tests/evaluate-conditions-test.js
@@ -12,6 +12,7 @@ var modelWithDeepConditionals = require('./fixtures/conditions/deep-model')
 var modelWithRelativePaths = require('./fixtures/conditions/relative-paths-model')
 var modelWithArray = require('./fixtures/conditions/array-model')
 var modelWithDefinitions = require('./fixtures/conditions/definitions-model')
+var modelWithUnless = require('./fixtures/conditions/unless-model')
 
 /**
  * Used to deference the
@@ -48,6 +49,55 @@ describe('evaluate-conditions', () => {
           'enum': ['untagged', 'single-tagged', 'double-tagged', 'foo-tagged']
         }
       }
+    })
+  })
+
+  describe('conditional properties with "unless"', function () {
+    it('are hidden if an "unless" condition is met', function () {
+      var data = {
+        tagType: 'untagged'
+      }
+      model = _.cloneDeep(modelWithUnless)
+      var newModel = dereferenceAndEval(model, data)
+      expect(newModel).to.eql({
+        'type': 'object',
+        'properties': {
+          'tagType': {
+            'type': 'string',
+            'enum': ['untagged', 'single-tagged', 'double-tagged']
+          }
+        }
+      })
+    })
+    it('are not hidden if an "unless" no condition is met', function () {
+      var data = {
+        tagType: 'double-tagged'
+      }
+      model = _.cloneDeep(modelWithUnless)
+      var newModel = dereferenceAndEval(model, data)
+      expect(newModel).to.eql({
+        type: 'object',
+        properties: {
+          tagType: {
+            type: 'string',
+            enum: ['untagged', 'single-tagged', 'double-tagged']
+          },
+          tag: {
+            type: 'number',
+            default: 20,
+            multipleOf: 1.0,
+            minimum: 0,
+            maximum: 4094
+          },
+          tag2: {
+            type: 'number',
+            default: 3000,
+            multipleOf: 1.0,
+            minimum: 0,
+            maximum: 4094
+          }
+        }
+      })
     })
   })
 

--- a/tests/fixtures/conditions/unless-model.js
+++ b/tests/fixtures/conditions/unless-model.js
@@ -1,0 +1,40 @@
+/**
+ * Simple bunsen model with an 'unless' condition
+ */
+
+module.exports = {
+  type: 'object',
+  properties: {
+    tagType: {
+      type: 'string',
+      enum: ['untagged', 'single-tagged', 'double-tagged']
+    },
+    tag: {
+      type: 'number',
+      default: 20,
+      multipleOf: 1.0,
+      minimum: 0,
+      maximum: 4094,
+      conditions: [{
+        unless: [{
+          tagType: {equals: 'untagged'}
+        }]
+      }]
+    },
+    tag2: {
+      type: 'number',
+      default: 3000,
+      multipleOf: 1.0,
+      minimum: 0,
+      maximum: 4094,
+      conditions: [{
+        unless: [{
+          tagType: {equals: 'single-tagged'}
+        },
+        {
+          tagType: {equals: 'untagged'}
+        }]
+      }]
+    }
+  }
+}


### PR DESCRIPTION
Fixed an issue with the "unless" keyword for model conditions.
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**Added** "unless" functionality to model conditionals