### PR TITLE
Arrays valid as itemCell property.

### DIFF
--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -21,7 +21,17 @@ const definitions = {
 
       // the cell config for individual items in the array
       itemCell: {
-        '$ref': '#/definitions/cell'
+        oneOf: [
+          {
+            '$ref': '#/definitions/cell'
+          },
+          {
+            type: 'array',
+            items: {
+              '$ref': '#/definitions/cell'
+            }
+          }
+        ]
       },
 
       // When true, show label for each item in the array


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
Arrays of cells will now pass validation for the `itemCell` property of views.