### PR TITLE
Normalization doesn't crash on bad models.

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,6 @@
 import _ from 'lodash'
 
 import {getPath} from './dereference'
-import normalizeModelAndView from './normalize-model-and-view'
 import {validateValue} from './validator'
 import {aggregateResults} from './validator/utils'
 
@@ -38,30 +37,13 @@ export function changeModel (model) {
 
 /**
  * Update view
- * @param {BunsenView} nextView - new bunsen view
+ * @param {BunsenView} view - new bunsen view
  * @returns {Object} redux action
  */
-export function changeView (nextView) {
-  return function (dispatch, getState) {
-    const baseModel = getState().baseModel
-
-    const {model, view} = normalizeModelAndView({
-      model: baseModel,
-      view: nextView
-    })
-
-    const action = {
-      type: CHANGE_VIEW,
-      unnormalizedView: nextView,
-      view
-    }
-
-    // If our view injected new properties into the model
-    if (model !== baseModel) {
-      action.baseModel = model
-    }
-
-    dispatch(action)
+export function changeView (view) {
+  return {
+    type: CHANGE_VIEW,
+    view
   }
 }
 

--- a/src/normalize-model-and-view.js
+++ b/src/normalize-model-and-view.js
@@ -58,7 +58,7 @@ function extendCell (cell, cellDefinitions) {
   cell = _.clone(cell)
   while (cell.extends) {
     const extendedCell = cellDefinitions[cell.extends]
-    if (extendedCell === undefined) {
+    if (!_.isObject(extendedCell)) {
       throw new Error(`'${cell.extends}' is not a valid model definition`)
     }
     delete cell.extends
@@ -266,7 +266,13 @@ function expandModel (model, view) {
  * @returns {Object} - normalized state (contains model and view)
  */
 export default function ({model, view}) {
-  const expandedModel = expandModel(model, view)
-  const normalizedView = normalizeCells(view)
-  return {model: expandedModel, view: normalizedView}
+  try {
+    const expandedModel = expandModel(model, view)
+    const normalizedView = normalizeCells(view)
+    return {model: expandedModel, view: normalizedView}
+  } catch (e) {
+    // Unfortunately this is necessary because view validation happens outside of the reducer,
+    // so we have no guarantee that the view is valid and it may cause run time errors. Returning
+    return {model, view}
+  }
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -232,18 +232,10 @@ export const actionReducers = {
     // If we have an unnormalized view then we need to update our model to make
     // sure any model extensions defined in the view get applied
     if (state.unnormalizedView) {
-      let normalized
-      try {
-        normalized = normalizeModelAndView({
-          model: action.model,
-          view: state.unnormalizedView
-        })
-      } catch (e) {
-        normalized = {
-          model: action.model,
-          view: state.unnormalizedView
-        }
-      }
+      const normalized = normalizeModelAndView({
+        model: action.model,
+        view: state.unnormalizedView
+      })
       newState.baseModel = normalized.model
       newState.baseView = normalized.view
       newState.view = evaluateViewConditions(newState.baseView, state.value)
@@ -268,17 +260,10 @@ export const actionReducers = {
     let normalized
     let view
     if (state.unnormalizedModel) {
-      try {
-        normalized = normalizeModelAndView({
-          model: state.unnormalizedModel,
-          view: action.view
-        })
-      } catch (e) {
-        normalized = {
-          model: state.unnormalizedModel,
-          view: action.view
-        }
-      }
+      normalized = normalizeModelAndView({
+        model: state.unnormalizedModel,
+        view: action.view
+      })
 
       view = evaluateViewConditions(normalized.view, state.value)
     } else {

--- a/tests/normalize-model-and-view-test.js
+++ b/tests/normalize-model-and-view-test.js
@@ -529,7 +529,7 @@ describe('normalize model and view', function () {
       }
     })
   })
-  it('default export throws an error when a non-existing cell definition is extended', () => {
+  it('default export returns model and view unchanged when non-existing cell definition is extended', () => {
     const model = {
       type: 'object',
       properties: {
@@ -550,10 +550,39 @@ describe('normalize model and view', function () {
       type: 'form',
       version: '2.0'
     }
-    const referenceBadDef = function () {
-      stuff.default({view, model})
+
+    const normalized = stuff.default({view, model})
+
+    expect(normalized.model).to.be.equal(model)
+    expect(normalized.view).to.be.equal(view)
+  })
+
+  it('default export returns model and view unchanged when extended cell is bad', () => {
+    const model = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string'
+        }
+      }
     }
-    expect(referenceBadDef).to.throw()
+    const view = {
+      cellDefinitions: {
+        bar: 'baz'
+      },
+      cells: [
+        {
+          model: 'foo',
+          extends: 'bar'
+        }
+      ],
+      type: 'form',
+      version: '2.0'
+    }
+    const normalized = stuff.default({view, model})
+
+    expect(normalized.model).to.be.equal(model)
+    expect(normalized.view).to.be.equal(view)
   })
 })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
Incorrect views no longer cause normalization to crash. Instead, model and view are returned unchanged.