### PR TITLE
Added variable paths to ValueWrapper

### DIFF
--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import {parseVariables} from '../utils'
 
 /* eslint-disable complexity */
 /**
@@ -48,7 +49,7 @@ export class ValueWrapper {
 
   constructor (value, curPath) {
     this.value = value
-    this.path = ValueWrapper.pathAsArray(curPath)
+    this.path = ValueWrapper.pathAsArray(parseVariables(this.value, curPath))
   }
 
   /**
@@ -70,6 +71,7 @@ export class ValueWrapper {
       }
       return _.get(this.value, this.path.join('.'))
     }
+    path = parseVariables(this.value, path)
     path = path.split('./')
 
     if (path.length <= 1) {
@@ -94,7 +96,7 @@ export class ValueWrapper {
     if (path === undefined) {
       return this
     }
-    path = ValueWrapper.pathAsArray(path)
+    path = ValueWrapper.pathAsArray(parseVariables(this.value, path))
     return new ValueWrapper(this.value, this.path.concat(path))
   }
 }

--- a/tests/validator/utils/path-test.js
+++ b/tests/validator/utils/path-test.js
@@ -25,6 +25,11 @@ describe('utils/path', () => {
               quux: 'test 2'
             }
           }
+        },
+        pathVariables: {
+          constructorPath: 'foo.bar2.baz.quux',
+          path1: './baz.quux',
+          path2: 'quux'
         }
       }, 'foo.bar1.baz')
     })
@@ -39,6 +44,12 @@ describe('utils/path', () => {
         }
       })
     })
+
+    it('constructs with an initial ', function () {
+      wrapper = new ValueWrapper(wrapper.value, '${pathVariables.constructorPath}')
+      expect(wrapper.get()).to.eql('test 2')
+    })
+
     describe('get method', function () {
       it('gets properties from a path in the base object', function () {
         expect(wrapper.get('foo.bar1.baz.quux')).to.eql('test 1')
@@ -50,17 +61,22 @@ describe('utils/path', () => {
 
         expect(newWrapper.get('../../quux')).to.eql('test 1')
       })
+      it('handles variable paths', function () {
+        expect(wrapper.get('${pathVariables.path1}')).to.eql('test 1')
+      })
     })
     describe('pushPath method', function () {
-      var newWrapper
-      beforeEach(function () {
-        newWrapper = wrapper.pushPath('must.go.deeper')
-      })
       it('appends to the contained path', function () {
+        var newWrapper = wrapper.pushPath('must.go.deeper')
         expect(newWrapper.get()).to.eql(true)
       })
       it('returns a new object', function () {
+        var newWrapper = wrapper.pushPath('must.go.deeper')
         expect(newWrapper).to.not.equal(wrapper)
+      })
+      it('handles variable paths', function () {
+        var newWrapper = wrapper.pushPath('${pathVariables.path2}')
+        expect(newWrapper.get()).to.eql('test 1')
       })
     })
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
ValueWrapper class now supports variable paths using `${}` notation used by other features (like `queryPath` option). This will allow `recordsPath` option to support variable paths.