### PR TITLE
Fixed path finding for internal models

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -270,10 +270,16 @@ export class BunsenModelPath {
     if (!this._valid || pathSeg === undefined) {
       return
     }
+    let segments
     if (Array.isArray(pathSeg)) {
-      pathSeg.forEach(seg => this.append(seg))
-      return
+      segments = pathSeg
+    } else {
+      segments = pathSeg.split('.')
     }
+    segments.forEach(seg => this._append(seg))
+  }
+
+  _append (pathSeg) {
     const curModel = this._currentModel
     const prePath = BunsenModelPath.getPrePath(curModel, pathSeg)
     const nextSeg = BunsenModelPath.createPathSegment(curModel, prePath, pathSeg)

--- a/tests/utils-test.js
+++ b/tests/utils-test.js
@@ -476,6 +476,71 @@ describe('utils', () => {
         'items.properties.foo.properties.bar.items.1.properties.baz.additionalItems.properties.qux'
       )
     })
+    describe('.append()', function () {
+      let modelPath
+      beforeEach(function () {
+        const model = {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'object',
+                properties: {
+                  bar: {
+                    type: 'array',
+                    items: [{
+                      type: 'string'
+                    }, {
+                      type: 'object',
+                      properties: {
+                        baz: {
+                          type: 'array',
+                          items: [{
+                            type: 'string'
+                          }],
+                          additionalItems: {
+                            type: 'object',
+                            properties: {
+                              qux: {type: 'string'}
+                            }
+                          }
+                        }
+                      }
+                    }]
+                  }
+                }
+              },
+              bar: {
+                type: 'string'
+              }
+            },
+            dependencies: {
+              foo: ['bar']
+            }
+          }
+        }
+        // const path = '0.foo.bar.1.baz.4.qux'
+        const path = '0.foo'
+        modelPath = new utils.BunsenModelPath(model, path)
+      })
+      it('adds a path segment to the path', function () {
+        modelPath.append('bar')
+        expect(modelPath.toString()).to.be.equal('items.properties.foo.properties.bar')
+      })
+      it('adds an array of path segments to the path', function () {
+        modelPath.append(['bar', '1', 'baz', '4', 'qux'])
+        expect(modelPath.toString()).to.be.equal(
+          'items.properties.foo.properties.bar.items.1.properties.baz.additionalItems.properties.qux'
+        )
+      })
+      it('adds multiple path segments when the path segment is dotted notation', function () {
+        modelPath.append('bar.1.baz.4.qux')
+        expect(modelPath.toString()).to.be.equal(
+          'items.properties.foo.properties.bar.items.1.properties.baz.additionalItems.properties.qux'
+        )
+      })
+    })
     describe('when a path on invalid path', function () {
       let modelPath
       beforeEach(function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**Fixed** how BunsenModelPath handles appending string paths using dot notation. This was causing internal models to be added to the wrong spot in the bunsen model if the cell defining the internal model used dot notation.
