### PR TITLE
Use the dereferenced model when normalizing views

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -233,7 +233,7 @@ export const actionReducers = {
     // sure any model extensions defined in the view get applied
     if (state.unnormalizedView) {
       const normalized = normalizeModelAndView({
-        model: action.model,
+        model: newState.unnormalizedModel,
         view: state.unnormalizedView
       })
       newState.baseModel = normalized.model

--- a/tests/reducer/change-model-test.js
+++ b/tests/reducer/change-model-test.js
@@ -3,7 +3,7 @@ var actions = require('../../lib/actions')
 var reducer = require('../../lib/reducer').reducer
 
 describe('reducer: CHANGE_MODEL', function () {
-  let initialState
+  var initialState
   beforeEach(function () {
     initialState = {
       baseModel: {
@@ -33,7 +33,7 @@ describe('reducer: CHANGE_MODEL', function () {
   })
 
   describe('when model does not include references', function () {
-    let newState
+    var newState
     beforeEach(function () {
       newState = reducer(initialState, {
         type: actions.CHANGE_MODEL,
@@ -47,7 +47,7 @@ describe('reducer: CHANGE_MODEL', function () {
   })
 
   describe('when model includes complex references', function () {
-    let newState
+    var newState
     beforeEach(function () {
       newState = reducer(initialState, {
         type: actions.CHANGE_MODEL,

--- a/tests/reducer/change-model-test.js
+++ b/tests/reducer/change-model-test.js
@@ -1,0 +1,98 @@
+var expect = require('chai').expect
+var actions = require('../../lib/actions')
+var reducer = require('../../lib/reducer').reducer
+
+describe('reducer: CHANGE_MODEL', function () {
+  let initialState
+  beforeEach(function () {
+    initialState = {
+      baseModel: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'object',
+                properties: {
+                  baz: {type: 'object'}
+                }
+              }
+            }
+          }
+        }
+      },
+      unnormalizedView: {
+        type: 'form',
+        version: '2.0',
+        cells: [{
+          model: 'foo.bar.baz'
+        }]
+      }
+    }
+  })
+
+  describe('when model does not include references', function () {
+    let newState
+    beforeEach(function () {
+      newState = reducer(initialState, {
+        type: actions.CHANGE_MODEL,
+        model: initialState.baseModel
+      })
+    })
+
+    it('returns the new model', function () {
+      expect(newState.model).to.eql(initialState.baseModel)
+    })
+  })
+
+  describe('when model includes complex references', function () {
+    let newState
+    beforeEach(function () {
+      newState = reducer(initialState, {
+        type: actions.CHANGE_MODEL,
+        model: {
+          type: 'object',
+          definitions: {
+            barbaz: {
+              type: 'object',
+              properties: {
+                bar: {
+                  type: 'object',
+                  properties: {
+                    baz: {type: 'string'}
+                  }
+                }
+              }
+            }
+          },
+          properties: {
+            foo: {
+              type: 'object',
+              '$ref': '#/definitions/barbaz'
+            }
+          }
+        }
+      })
+    })
+
+    it('returns the new model fully expanded', function () {
+      expect(newState.model).to.eql({
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'object',
+                properties: {
+                  baz: {type: 'string'}
+                }
+              }
+            }
+          }
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug that cause the view normalization to error out when complex references were used.
