### PR TITLE
Add new options for select/multi-select renderers

### DIFF
--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -552,6 +552,16 @@ const definitions = {
             type: 'boolean'
           },
 
+          // whether or not to pin selected items in multi-select dropdown when not filtering locally
+          pinSelectedValues: {
+            type: 'boolean'
+          },
+
+          // whether or not to update items using query on dropdown open
+          updateItemsOnOpen: {
+            type: 'boolean'
+          },
+
           // description: where in API response to find records for list-based inputs
           recordsPath: {
             type: 'string'
@@ -596,6 +606,16 @@ const definitions = {
 
       // whether or not to try to query for the current value when Ember Data is used to populate options
       queryForCurrentValue: {
+        type: 'boolean'
+      },
+
+      // whether or not to pin selected items in multi-select dropdown when not filtering locally
+      pinSelectedValues: {
+        type: 'boolean'
+      },
+
+      // whether or not to update items using query on dropdown open
+      updateItemsOnOpen: {
         type: 'boolean'
       },
 

--- a/tests/validator/view-schemas/v2-test.js
+++ b/tests/validator/view-schemas/v2-test.js
@@ -23,6 +23,8 @@ describe('v2 schema validation', () => {
             {
               model: 'foo',
               renderer: {
+                pinSelectedValues: true,
+                updateItemsOnOpen: true,
                 data: [{
                   label: 'label',
                   value: 'value'
@@ -110,6 +112,78 @@ describe('v2 schema validation', () => {
           expect(schemaValidator.validate(value, model)).to.equal(false)
         })
       })
+
+      describe('when pinSelectedValues option is specified', function () {
+        it('passes validation when pinSelectedValues is boolean', function () {
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('fails validation when value is number', function () {
+          value.cells[0].renderer.pinSelectedValues = 1.1
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is integer', function () {
+          value.cells[0].renderer.pinSelectedValues = 1
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is string', function () {
+          value.cells[0].renderer.pinSelectedValues = 'value'
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('passes validation when value is object', function () {
+          value.cells[0].renderer.pinSelectedValues = {}
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is an array', function () {
+          value.cells[0].renderer.pinSelectedValues = []
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is null', function () {
+          value.cells[0].renderer.pinSelectedValues = null
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+      })
+
+      describe('when updateItemsOnOpen option is specified', function () {
+        it('passes validation when updateItemsOnOpen is boolean', function () {
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('fails validation when value is number', function () {
+          value.cells[0].renderer.updateItemsOnOpen = 1.1
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is integer', function () {
+          value.cells[0].renderer.updateItemsOnOpen = 1
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is string', function () {
+          value.cells[0].renderer.updateItemsOnOpen = 'value'
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('passes validation when value is object', function () {
+          value.cells[0].renderer.updateItemsOnOpen = {}
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is an array', function () {
+          value.cells[0].renderer.updateItemsOnOpen = []
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is null', function () {
+          value.cells[0].renderer.updateItemsOnOpen = null
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+      })
     })
 
     describe('when properties set on renderer.options', function () {
@@ -124,6 +198,8 @@ describe('v2 schema validation', () => {
               renderer: {
                 name: 'select',
                 options: {
+                  pinSelectedValues: true,
+                  updateItemsOnOpen: true,
                   data: [{
                     label: 'label',
                     value: 'value'
@@ -208,6 +284,78 @@ describe('v2 schema validation', () => {
 
         it('fails validation when value is null', function () {
           value.cells[0].renderer.options.none.value = null
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+      })
+
+      describe('when pinSelectedValues option is specified', function () {
+        it('passes validation when pinSelectedValues is boolean', function () {
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('fails validation when value is number', function () {
+          value.cells[0].renderer.options.pinSelectedValues = 1.1
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is integer', function () {
+          value.cells[0].renderer.options.pinSelectedValues = 1
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is string', function () {
+          value.cells[0].renderer.options.pinSelectedValues = 'value'
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('passes validation when value is object', function () {
+          value.cells[0].renderer.options.pinSelectedValues = {}
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is an array', function () {
+          value.cells[0].renderer.options.pinSelectedValues = []
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is null', function () {
+          value.cells[0].renderer.options.pinSelectedValues = null
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+      })
+
+      describe('when updateItemsOnOpen option is specified', function () {
+        it('passes validation when updateItemsOnOpen is boolean', function () {
+          expect(schemaValidator.validate(value, model)).to.equal(true)
+        })
+
+        it('fails validation when value is number', function () {
+          value.cells[0].renderer.options.updateItemsOnOpen = 1.1
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is integer', function () {
+          value.cells[0].renderer.options.updateItemsOnOpen = 1
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is string', function () {
+          value.cells[0].renderer.options.updateItemsOnOpen = 'value'
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('passes validation when value is object', function () {
+          value.cells[0].renderer.options.updateItemsOnOpen = {}
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is an array', function () {
+          value.cells[0].renderer.options.updateItemsOnOpen = []
+          expect(schemaValidator.validate(value, model)).to.equal(false)
+        })
+
+        it('fails validation when value is null', function () {
+          value.cells[0].renderer.options.updateItemsOnOpen = null
           expect(schemaValidator.validate(value, model)).to.equal(false)
         })
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

**pinSelectedValues** - If this option is enabled, selected items will be pinned to the top of the dropdown list in the multi-select dropdown.
**updateItemsOnOpen** - If this option is enabled, items in the dropdown will be refreshed every time the dropdown is opened.

This PR only contains the schema validation so that these options can be used within the select/multi-select renderers. `pinSelectedValues` is only meant to be used with the multi-select renderer and if used with the select renderer it would have no effect. However, it would still pass schema validation.

# CHANGELOG
- **Added** new options for select/multi-select renderers 
