### PR TITLE
Merge defaults

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -169,7 +169,33 @@ function dispatchUpdatedResults (dispatch, results) {
   dispatch(updateValidationResults(aggregatedResult))
 }
 
-/*eslint-disable complexity */
+function getDefaultedValue ({inputValue, previousValue, bunsenId, renderModel, mergeDefaults}) {
+  const isInputValueEmpty = isEmptyValue(inputValue)
+
+  if (previousValue !== undefined) {
+    return inputValue
+  }
+
+  const resolveRef = schemaFromRef(renderModel.definitions)
+  const defaultValue = getDefaults(inputValue, bunsenId, renderModel, resolveRef)
+  const hasDefaults = defaultValue !== undefined
+  const isUpdatingAll = bunsenId === null
+
+  const shouldApplyDefaults = isInputValueEmpty && hasDefaults ||
+    !isInputValueEmpty && hasDefaults && isUpdatingAll && mergeDefaults
+  const shouldClear = isInputValueEmpty && isUpdatingAll && !hasDefaults
+
+  console.log('shouldClear: ', shouldClear)
+  console.log('shouldApplyDefaults', shouldApplyDefaults)
+  if (shouldApplyDefaults) {
+    return _.defaults({}, inputValue, defaultValue)
+  } else if (shouldClear) {
+    return {}
+  }
+
+  return inputValue
+}
+
 /**
  * Validate action
  * @param {String} bunsenId - bunsen ID of what changed
@@ -178,29 +204,17 @@ function dispatchUpdatedResults (dispatch, results) {
  * @param {Array<Function>} validators - custom validators
  * @param {Function} [all=Promise.all] - framework specific Promise.all method
  * @param {Boolean} [forceValidation=false] - whether or not to force validation
+ * @param {Boolean} [mergeDefaults=false] - whether to merge defaults with initial values
  * @returns {Function} Function to asynchronously validate
  */
 export function validate (
-  bunsenId, inputValue, renderModel, validators, all = Promise.all, forceValidation = false
+  bunsenId, inputValue, renderModel, validators, all = Promise.all, forceValidation = false, mergeDefaults = false
 ) {
   return function (dispatch, getState) {
     let formValue = getState().value
-
-    const isInputValueEmpty = isEmptyValue(inputValue)
-
     const previousValue = _.get(formValue, bunsenId)
 
-    // If an empty value has been provided and there is no previous value then
-    // make sure to apply defaults from the model
-    if (isInputValueEmpty && previousValue === undefined) {
-      const resolveRef = schemaFromRef(renderModel.definitions)
-      const defaultValue = getDefaults(inputValue, bunsenId, renderModel, resolveRef)
-      if (bunsenId === null && defaultValue === undefined) {
-        inputValue = {}
-      } else if (defaultValue !== undefined) {
-        inputValue = defaultValue
-      }
-    }
+    inputValue = getDefaultedValue({inputValue, previousValue, bunsenId, renderModel, mergeDefaults})
 
     // if the value never changed, no need to update and validate (unless consumer
     // is forcing validation again)

--- a/src/actions.js
+++ b/src/actions.js
@@ -185,8 +185,6 @@ function getDefaultedValue ({inputValue, previousValue, bunsenId, renderModel, m
     !isInputValueEmpty && hasDefaults && isUpdatingAll && mergeDefaults
   const shouldClear = isInputValueEmpty && isUpdatingAll && !hasDefaults
 
-  console.log('shouldClear: ', shouldClear)
-  console.log('shouldApplyDefaults', shouldApplyDefaults)
   if (shouldApplyDefaults) {
     return _.defaults({}, inputValue, defaultValue)
   } else if (shouldClear) {

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -221,7 +221,11 @@ describe('validate action', function () {
     }
   }
 
-  function getDefaultValue (path, initialValue, schema, mergeDefaults = false) {
+  function getDefaultValue (path, initialValue, schema, mergeDefaults) {
+    if (mergeDefaults === undefined) {
+      mergeDefaults = true
+    }
+
     var thunk = actions.validate(
       path,
       initialValue,

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -223,7 +223,7 @@ describe('validate action', function () {
 
   function getDefaultValue (path, initialValue, schema, mergeDefaults) {
     if (mergeDefaults === undefined) {
-      mergeDefaults = true
+      mergeDefaults = false
     }
 
     var thunk = actions.validate(

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -221,8 +221,15 @@ describe('validate action', function () {
     }
   }
 
-  function getDefaultValue (path, initialValue, schema) {
-    var thunk = actions.validate(path, initialValue, schema, [])
+  function getDefaultValue (path, initialValue, schema, mergeDefaults = false) {
+    var thunk = actions.validate(
+      path,
+      initialValue,
+      schema,
+      [],
+      undefined,
+      false,
+      mergeDefaults)
     var defaultValue = {}
 
     thunk(function (action) {
@@ -231,8 +238,19 @@ describe('validate action', function () {
 
     return defaultValue
   }
+
   it('fills in defaults', function () {
     var defaultValue = getDefaultValue(null, {}, SCHEMA_WITH_DEFAULTS)
+    expect(defaultValue).to.eql({
+      firstName: 'Bruce',
+      lastName: 'Wayne',
+      alias: 'Batman',
+      onlyChild: true
+    })
+  })
+
+  it('should merge defaults when mergeDefaults is true', function () {
+    var defaultValue = getDefaultValue(null, {firstName: 'Bruce'}, SCHEMA_WITH_DEFAULTS, true)
     expect(defaultValue).to.eql({
       firstName: 'Bruce',
       lastName: 'Wayne',


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Adds** an extra parameter `mergeDefaults` to `actions.js:validate` that will merge the initial value with the defaults obtained from the model
* **Refactored** the default logic so it reads better and reduces complexity
