### PR TITLE
Prevent changeNestedFormValue from stripping File values

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -99,7 +99,7 @@ function changeEntireFormValue ({model, nextValue, prevValue}) {
 function changeNestedFormValue ({bunsenId, formValue, model, value}) {
   const segments = bunsenId.split('.')
   const lastSegment = segments.pop()
-  const isEmpty = _.isEmpty(value) && (Array.isArray(value) || _.isObject(value))
+  const isEmpty = _.isEmpty(value) && (Array.isArray(value) || _.isObject(value)) && !(value instanceof File)
 
   // Make sure form value is immutable
   formValue = immutableOnce(formValue)

--- a/tests/reducer-test.js
+++ b/tests/reducer-test.js
@@ -175,23 +175,47 @@ describe('reducer', function () {
       expect(changedState.value).to.eql(value)
     })
 
-    it('will not strip Files', function () {
-      var exampleFile = new File()
-      var initialState = {
-        errors: {},
-        validationResult: {warnings: [], errors: []},
-        value: {},
-        baseModel: {}
-      }
+    describe('When handling a File value', function () {
+      'use strict'
+      let exampleFile
 
-      var value = {
-        foo: {
-          bar: exampleFile
+      beforeEach(function () {
+        exampleFile = new File()
+      })
+
+      it('will not strip Files when changing the whole form value', function () {
+        let initialState = {
+          errors: {},
+          validationResult: {warnings: [], errors: []},
+          value: {},
+          baseModel: {}
         }
-      }
 
-      var changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: value, bunsenId: null})
-      expect(changedState.value).to.eql(value)
+        let value = {
+          foo: {
+            bar: exampleFile
+          }
+        }
+
+        let changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: value, bunsenId: null})
+        expect(changedState.value).to.eql(value)
+      })
+
+      it('will not strip Files when changing nested values', function () {
+        let initialState = {
+          errors: {},
+          validationResult: {warnings: [], errors: []},
+          value: {},
+          baseModel: {}
+        }
+
+        let expectedValue = {
+          file: exampleFile
+        }
+
+        let changedState = reducer(initialState, {type: actions.CHANGE_VALUE, value: exampleFile, bunsenId: 'file'})
+        expect(changedState.value).to.eql(expectedValue)
+      })
     })
 
     it('will prune all the dead wood when setting root object', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
- **Fixed** a bug where File values were being removed from nested form values
