### PR TITLE
Add form renderer schema

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -4,6 +4,7 @@ import {getPath} from './dereference'
 import {validateValue} from './validator'
 import {aggregateResults} from './validator/utils'
 
+export const CHANGE = 'CHANGE'
 export const CHANGE_VALUE = 'CHANGE_VALUE'
 export const VALIDATION_RESOLVED = 'VALIDATION_RESOLVED'
 export const CHANGE_MODEL = 'SET_MODEL'
@@ -43,6 +44,14 @@ export function changeModel (model) {
 export function changeView (view) {
   return {
     type: CHANGE_VIEW,
+    view
+  }
+}
+
+export function change ({model, view, value}) {
+  return {
+    type: CHANGE,
+    model,
     view
   }
 }

--- a/src/immutable-utils.js
+++ b/src/immutable-utils.js
@@ -15,7 +15,7 @@ function unsetArray (obj, path, segments) {
   return obj.slice(0, index).concat([newValue]).concat(obj.slice(index + 1))
 }
 
-function unsetObject (obj, path, segments) {
+export function unsetObject (obj, path, segments) {
   const key = segments.splice(0, 1)
 
   if (segments.length === 0) {

--- a/src/immutable-utils.js
+++ b/src/immutable-utils.js
@@ -22,8 +22,12 @@ function unsetObject (obj, path, segments) {
     return obj.without(key)
   }
 
-  const newValue = unset(obj[key], segments.join('.'))
-  return obj.set(key, newValue)
+  if (key in obj) {
+    const newValue = unset(obj[key], segments.join('.'))
+    return obj.set(key, newValue)
+  }
+
+  return obj
 }
 
 function padArray (array, desiredLength) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import {
   VALIDATION_RESOLVED,
   change,
   changeModel,
-  changeModelAndView,
   changeValue,
   changeView,
   updateValidationResults,

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,12 @@
 import {
+  CHANGE,
   CHANGE_MODEL,
   CHANGE_VALUE,
   CHANGE_VIEW,
   VALIDATION_RESOLVED,
+  change,
   changeModel,
+  changeModelAndView,
   changeValue,
   changeView,
   updateValidationResults,
@@ -11,6 +14,8 @@ import {
 } from './actions'
 
 export const actions = {
+  CHANGE,
+  change,
   CHANGE_MODEL,
   changeModel,
   CHANGE_VIEW,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -2,7 +2,7 @@
 import _ from 'lodash'
 import immutable from 'seamless-immutable'
 
-import {CHANGE_MODEL, CHANGE_VALUE, CHANGE_VIEW, VALIDATION_RESOLVED} from './actions'
+import {CHANGE, CHANGE_MODEL, CHANGE_VALUE, CHANGE_VIEW, VALIDATION_RESOLVED} from './actions'
 import {getChangeSet} from './change-utils'
 import {dereference} from './dereference'
 import evaluateConditions from './evaluate-conditions'
@@ -266,6 +266,25 @@ export const actionReducers = {
     }
 
     return _.defaults(newState, state)
+  },
+
+  [CHANGE]: function (state, action) {
+    let newState = state
+
+    if (action.value) {
+      newState = actionReducers[CHANGE_VALUE](newState, action)
+    }
+
+    if (action.model) {
+      newState = actionReducers[CHANGE_MODEL](newState, action)
+    }
+
+    if (action.view) {
+      newState = actionReducers[CHANGE_VIEW](newState, action)
+    }
+
+    newState.lastAction = CHANGE
+    return newState
   },
 
   /* eslint-disable complexity */

--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -250,6 +250,7 @@ const definitions = {
           {'$ref': '#/definitions/buttonGroupRenderer'},
           {'$ref': '#/definitions/checkboxArrayRenderer'},
           {'$ref': '#/definitions/customRenderer'},
+          {'$ref': '#/definitions/formRenderer'},
           {'$ref': '#/definitions/linkRenderer'},
           {'$ref': '#/definitions/numberRenderer'},
           {'$ref': '#/definitions/passwordRenderer'},
@@ -343,11 +344,31 @@ const definitions = {
       name: {
         type: 'string',
         /* eslint-disable max-len */
-        pattern: '^(?!boolean$|button-group$|checkbox-array$|link$|multi-select$|number$|password$|select$|string$|table$|textarea$|url$).*'
+        pattern: '^(?!boolean$|button-group$|checkbox-array$|form$|link$|multi-select$|number$|password$|select$|string$|table$|textarea$|url$).*'
         /* eslint-enable max-len */
       }
     },
     type: 'object'
+  },
+
+  formRenderer: {
+    additionalProperties: false,
+    properties: {
+      name: {
+        type: 'string',
+        enum: ['form']
+      },
+
+      plugin: {
+        name: {
+          type: 'string'
+        },
+        args: {
+          type: 'object',
+          additionalProperties: true
+        }
+      }
+    }
   },
 
   // link renderer options

--- a/tests/immutable-utils-test.js
+++ b/tests/immutable-utils-test.js
@@ -3,6 +3,7 @@ var immutable = require('seamless-immutable')
 var immutableHelpers = require('../lib/immutable-utils')
 var set = immutableHelpers.set
 var unset = immutableHelpers.unset
+var unsetObject = immutableHelpers.unsetObject
 
 /**
  * Check if two immutable objects are the same
@@ -1004,5 +1005,15 @@ describe('unset', function () {
         foo: {}
       })
     })
+  })
+})
+
+describe('unsetObject', function () {
+  it('should not error when path is unvailable in object', function () {
+    expect(function () {
+      unsetObject(immutable({
+        foo: 'bar'
+      }), undefined, ['baz'])
+    }).to.not.throw()
   })
 })

--- a/tests/reducer-test.js
+++ b/tests/reducer-test.js
@@ -22,6 +22,7 @@ describe('reducer', function () {
 
   ;[
     REDUX_INIT,
+    actions.CHANGE,
     actions.CHANGE_MODEL,
     actions.CHANGE_VALUE,
     actions.VALIDATION_RESOLVED
@@ -62,6 +63,100 @@ describe('reducer', function () {
         })
       })
     })
+
+  describe('when action type is CHANGE', function () {
+    beforeEach(function () {
+      sandbox.stub(actionReducers, actions.CHANGE_VALUE).returns({})
+      sandbox.stub(actionReducers, actions.CHANGE_VIEW).returns({})
+      sandbox.stub(actionReducers, actions.CHANGE_MODEL).returns({})
+    })
+
+    describe('when action.value is set', function () {
+      beforeEach(function () {
+        reducer({}, {
+          type: actions.CHANGE,
+          value: {}
+        })
+      })
+
+      it('should call the CHANGE_VALUE reducer', function () {
+        expect(actionReducers[actions.CHANGE_VALUE].callCount).to.equal(1)
+      })
+
+      it('should not call the CHANGE_MODEL reducer', function () {
+        expect(actionReducers[actions.CHANGE_MODEL].callCount).to.equal(0)
+      })
+
+      it('should not call the CHANGE_VIEW reducer', function () {
+        expect(actionReducers[actions.CHANGE_VIEW].callCount).to.equal(0)
+      })
+    })
+
+    describe('when action.model is set', function () {
+      beforeEach(function () {
+        reducer({}, {
+          type: actions.CHANGE,
+          model: {}
+        })
+      })
+
+      it('should not call the CHANGE_VALUE reducer', function () {
+        expect(actionReducers[actions.CHANGE_VALUE].callCount).to.equal(0)
+      })
+
+      it('should call the CHANGE_MODEL reducer', function () {
+        expect(actionReducers[actions.CHANGE_MODEL].callCount).to.equal(1)
+      })
+
+      it('should not call the CHANGE_VIEW reducer', function () {
+        expect(actionReducers[actions.CHANGE_VIEW].callCount).to.equal(0)
+      })
+    })
+
+    describe('when action.model/view/value is set', function () {
+      beforeEach(function () {
+        reducer({}, {
+          type: actions.CHANGE,
+          model: {},
+          value: {},
+          view: {}
+        })
+      })
+
+      it('should call the CHANGE_VALUE reducer', function () {
+        expect(actionReducers[actions.CHANGE_VALUE].callCount).to.equal(1)
+      })
+
+      it('should call the CHANGE_MODEL reducer', function () {
+        expect(actionReducers[actions.CHANGE_MODEL].callCount).to.equal(1)
+      })
+
+      it('should call the CHANGE_VIEW reducer', function () {
+        expect(actionReducers[actions.CHANGE_VIEW].callCount).to.equal(1)
+      })
+    })
+
+    describe('when action.view is set', function () {
+      beforeEach(function () {
+        reducer({}, {
+          type: actions.CHANGE,
+          view: {}
+        })
+      })
+
+      it('should not call the CHANGE_VALUE reducer', function () {
+        expect(actionReducers[actions.CHANGE_VALUE].callCount).to.equal(0)
+      })
+
+      it('should not call the CHANGE_MODEL reducer', function () {
+        expect(actionReducers[actions.CHANGE_MODEL].callCount).to.equal(0)
+      })
+
+      it('should call the CHANGE_VIEW reducer', function () {
+        expect(actionReducers[actions.CHANGE_VIEW].callCount).to.equal(1)
+      })
+    })
+  })
 
   describe('unknown state', function () {
     var reducedState, state


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** schema validation for an upcoming built-in renderer
* **Added** a new reducer action type for handling global changes for optimization
* **Fixed** a bug in `immutable-utils` attempting to call `unset` on `undefined`

