### PR TITLE
Rewired how tuples work

### DIFF
--- a/src/evaluate-conditions.js
+++ b/src/evaluate-conditions.js
@@ -27,14 +27,7 @@ export default function evaluate (model, value, getPreviousValue) {
         return evaluate(itemModel, val, getPreviousValue)
       })
       if (model.additionalItems) {
-        let i
-        if (value !== undefined) {
-          for (i = model.items.length; i < value.length; i += 1) {
-            retModel.items.push(evaluate(model.additionalItems, value[i], getPreviousValue))
-          }
-        }
         retModel.additionalItems = evaluate(model.additionalItems, undefined, getPreviousValue)
-        retModel.tuple = true
       }
     } else if (Array.isArray(value)) {
       let itemSchemas = []

--- a/src/generator.js
+++ b/src/generator.js
@@ -40,6 +40,7 @@ function arrayCell (propertyName, model, cellDefinitions) {
     }
   }
 }
+
 function tupleCell (propertyName, model, cellDefinitions) {
   const tupleCells = model.items.map((item, index) => {
     const cell = addModel(`${propertyName}/${index}`, item, cellDefinitions)
@@ -50,16 +51,14 @@ function tupleCell (propertyName, model, cellDefinitions) {
     model: propertyName,
     arrayOptions: {}
   }
-  if (model.tuple) {
-    cell.arrayOptions.tupleCells = tupleCells
-    if (model.additionalItems && typeof model.additionalItems === 'object') {
-      cell.arrayOptions.itemCell = {
-        extends: addModelCell(propertyName + 'Items', model.additionalItems, cellDefinitions)
-      }
+
+  cell.arrayOptions.tupleCells = tupleCells
+  if (model.additionalItems && typeof model.additionalItems === 'object') {
+    cell.arrayOptions.itemCell = {
+      extends: addModelCell(propertyName + 'Items', model.additionalItems, cellDefinitions)
     }
-  } else {
-    cell.arrayOptions.itemCell = tupleCells
   }
+
   return cell
 }
 

--- a/tests/evaluate-conditions-test.js
+++ b/tests/evaluate-conditions-test.js
@@ -338,6 +338,7 @@ describe('evaluate-conditions', () => {
         })
       })
     })
+
     it('handles tuple style arrays', function () {
       model = _.cloneDeep(modelWithTupleArray)
       expected = {
@@ -349,7 +350,6 @@ describe('evaluate-conditions', () => {
           },
           foo: {
             type: 'array',
-            tuple: true,
             items: [{
               type: 'string'
             }, {

--- a/tests/fixtures/tuple-view.js
+++ b/tests/fixtures/tuple-view.js
@@ -10,11 +10,21 @@ module.exports = {
         model: 'bar'
       }]
     },
+    'fooItems': {
+      children: [
+        {
+          model: 'baz'
+        }
+      ]
+    },
     main: {
       children: [{
         model: 'foo',
         arrayOptions: {
-          itemCell: [{
+          itemCell: {
+            extends: 'fooItems'
+          },
+          tupleCells: [{
             model: '0',
             extends: 'foo/0'
           }, {

--- a/tests/view-conditionals-test.js
+++ b/tests/view-conditionals-test.js
@@ -411,4 +411,76 @@ describe('views with conditionals', function () {
       version: '2.0'
     })
   })
+
+  describe('array conditions', function () {
+    let view
+    beforeEach(function () {
+      view = {
+        type: 'form',
+        version: '2.0',
+        cells: [{
+          model: 'name',
+          arrayOptions: {
+            itemCell: {
+              label: 'Name',
+              model: 'personType',
+              conditions: [{
+                if: [{
+                  './personType': {
+                    equals: 'Superhero'
+                  }
+                }],
+                then: {
+                  label: 'Superhero Name'
+                }
+              }]
+            }
+          }
+        }]
+      }
+    })
+
+    describe('when array conditionals evaluate to different schemas', function () {
+      let newView
+      beforeEach(function () {
+        newView = evaluate(view, {
+          name: [{
+            personType: 'Superhero'
+          }, {
+            personType: 'Normal hero'
+          }]
+        })
+      })
+
+      it('should create separate itemCells for each array item', function () {
+        expect(newView.cells[0].arrayOptions.itemCell).to.eql([{
+          label: 'Superhero Name',
+          model: 'personType'
+        }, {
+          label: 'Name',
+          model: 'personType'
+        }])
+      })
+    })
+
+    describe('when array conditionals evaluate to the same schemas', function () {
+      let newView
+      beforeEach(function () {
+        newView = evaluate(view, {
+          name: [{
+            personType: 'Superhero'
+          }, {
+            personType: 'Superhero'
+          }]
+        })
+      })
+
+      it('should not create separate itemCells for each array item', function () {
+        expect(newView.cells[0].arrayOptions.itemCell).to.eql({
+          label: 'Superhero Name',
+          model: 'personType'
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [x] #major# - incompatible API change

# CHANGELOG

## Breaking Change

* Altered how tuples are processed. It now aligns more closely to JSON Schema spec for tuples. Instead of using both `itemCell` and `tupleCells`, `tupleCells` is the only way to override the view while `itemCell` is remains as the view for homogenous array items. `itemCell` can be used as the `additionalItems` schema as well. `itemCell` can be an array but is independent of tuples.
* Fixed a performance issue where evaluating a condition on the view or model would override the schemas to introduce additional item schemas to match the current value.
