### PR TITLE
Fix defaults for non-object changes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -178,6 +178,16 @@ function dispatchUpdatedResults (dispatch, results) {
   dispatch(updateValidationResults(aggregatedResult))
 }
 
+/**
+ * Returns the default value for the given model
+ *
+ * @param {Object} inputValue - form value at the given bunsen path
+ * @param {Object} previousValue - the previous form value at the given bunsen path
+ * @param {String} bunsenId - the bunsen path id
+ * @param {Object} renderModel - the bunsen model without conditions
+ * @param {Boolean} mergeDefaults - whether to force a default value on a non-empty value
+ */
+/* eslint-disable complexity */
 function getDefaultedValue ({inputValue, previousValue, bunsenId, renderModel, mergeDefaults}) {
   const isInputValueEmpty = isEmptyValue(inputValue)
 
@@ -195,7 +205,8 @@ function getDefaultedValue ({inputValue, previousValue, bunsenId, renderModel, m
   const shouldClear = isInputValueEmpty && isUpdatingAll && !hasDefaults
 
   if (shouldApplyDefaults) {
-    return _.defaults({}, inputValue, defaultValue)
+    const schema = findSchema(renderModel, bunsenId, resolveRef)
+    return schema.type === 'object' ? _.defaults({}, inputValue, defaultValue) : defaultValue
   } else if (shouldClear) {
     return {}
   }

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -234,10 +234,12 @@ describe('validate action', function () {
       undefined,
       false,
       mergeDefaults)
-    var defaultValue = {}
 
+    let defaultValue
     thunk(function (action) {
-      _.assign(defaultValue, action.value)
+      if (action.value) {
+        defaultValue = action.value
+      }
     }, function () { return {} })
 
     return defaultValue
@@ -261,6 +263,12 @@ describe('validate action', function () {
       alias: 'Batman',
       onlyChild: true
     })
+  })
+
+  it('fills in defaults for non-object values', function () {
+    var defaultValue = getDefaultValue('someotherProp.name.firstName', {}, SCHEMA_WITH_DEEP_DEFAULTS)
+
+    expect(defaultValue).to.eql('Bruce')
   })
 
   it('fills in defaults for specific values', function () {

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -235,7 +235,7 @@ describe('validate action', function () {
       false,
       mergeDefaults)
 
-    let defaultValue
+    var defaultValue
     thunk(function (action) {
       if (action.value) {
         defaultValue = action.value


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug where clearing a field that was previously undefined had applied defaults with `_.defaults({}, defaultValue)` which would automatically turn it into an object, even if the value wasn't.
