### PR TITLE
Fixed redundant required validation for nested forms

### DIFF
--- a/tests/validator/utils-test.js
+++ b/tests/validator/utils-test.js
@@ -83,5 +83,71 @@ describe('validator/utils', () => {
         warnings: ['warning-1', 'warning-2', 'warning-3']
       })
     })
+
+    it('should return only unique required errors', function () {
+      results[0].errors = [{
+        isRequiredError: true,
+        path: '#/'
+      }, {
+        isRequiredError: true,
+        path: '#/'
+      }]
+
+      expect(utils.aggregateResults(results)).to.eql({
+        errors: [
+          'error-1',
+          'error-2',
+          {
+            isRequiredError: true,
+            path: '#/'
+          }
+        ],
+        warnings: ['warning-1', 'warning-2', 'warning-3']
+      })
+    })
+
+    it('should not return required errors that is the common ancestor', function () {
+      results[0].errors = [{
+        isRequiredError: true,
+        path: '#/a/'
+      }, {
+        isRequiredError: true,
+        path: '#/a/b/'
+      }]
+
+      expect(utils.aggregateResults(results)).to.eql({
+        errors: [
+          'error-1',
+          'error-2',
+          {
+            isRequiredError: true,
+            path: '#/a/b/'
+          }
+        ],
+        warnings: ['warning-1', 'warning-2', 'warning-3']
+      })
+    })
+
+    it('should not return required errors that is the common ancestor (2)', function () {
+      results[0].errors = [{
+        isRequiredError: true,
+        path: '#/a/b/'
+      }, {
+        isRequiredError: true,
+        path: '#/a'
+      }]
+
+      expect(utils.aggregateResults(results)).to.eql({
+        errors: [
+          'error-1',
+          'error-2',
+          {
+            isRequiredError: true,
+            path: '#/a/b/'
+          }
+        ],
+        warnings: ['warning-1', 'warning-2', 'warning-3']
+      })
+    })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** duplicate required validation errors for nested forms that send the same `isRequired` error for the same or similar object path. It now favors object paths that are descendants, which mean, the more accurate path.
