### PR TITLE
Limit onChange churn for trigger validation

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -234,17 +234,16 @@ export function validate (
 
     inputValue = getDefaultedValue({inputValue, previousValue, bunsenId, renderModel, mergeDefaults})
 
-    // if the value never changed, no need to update and validate (unless consumer
-    // is forcing validation again)
     if (!forceValidation && _.isEqual(inputValue, previousValue)) {
       return
     }
 
-    dispatch(changeValue(bunsenId, inputValue))
-
-    // We must lookup the formValue again in order for the validation results to
-    // be run on the post-change value rather than the pre-change value
-    formValue = getState().value
+    if (!forceValidation) {
+      dispatch(changeValue(bunsenId, inputValue))
+      // We must lookup the formValue again in order for the validation results to
+      // be run on the post-change value rather than the pre-change value
+      formValue = getState().value
+    }
 
     const result = validateValue(formValue, renderModel)
 

--- a/tests/actions-test.js
+++ b/tests/actions-test.js
@@ -415,14 +415,13 @@ describe('validate action', function () {
           }
         )
 
-        expect(spy.callCount).to.equal(2)
+        expect(spy.callCount).to.equal(1)
       })
     })
 
     describe('check property for changes', function () {
       it('does not dispatch action', function () {
         var thunk = actions.validate('alias', _.cloneDeep(state.value.alias), schema, [])
-
         thunk(
           spy,
           function () {
@@ -456,7 +455,7 @@ describe('validate action', function () {
           }
         )
 
-        expect(spy.callCount).to.equal(2)
+        expect(spy.callCount).to.equal(1)
       })
     })
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** issue with `triggerValidation` nullifying the form values which was due to it triggering an `onChange` with no value changes present. Removed the extra `onChange` as `triggerValidation` was meant only to force a validation on existing values.
