### PR TITLE
Update the model properly after a view is normalized

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -261,7 +261,7 @@ export const actionReducers = {
     if (!_.isEqual(state.baseModel, normalized.model)) {
       Object.assign(newState, {
         baseModel: normalized.model,
-        model: evaluateConditions(action.baseModel, state.value)
+        model: evaluateConditions(normalized.model, state.value)
       })
     }
 

--- a/tests/reducer/change-view-test.js
+++ b/tests/reducer/change-view-test.js
@@ -1,0 +1,72 @@
+var expect = require('chai').expect
+var actions = require('../../lib/actions')
+var reducer = require('../../lib/reducer').reducer
+
+describe('reducer: CHANGE_VIEW', function () {
+  var initialState, baseModel
+  beforeEach(function () {
+    baseModel = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'object'
+        }
+      }
+    }
+    initialState = {
+      baseModel,
+      unnormalizedModel: baseModel
+    }
+  })
+
+  describe('when view containers internal models', function () {
+    var newState
+    beforeEach(function () {
+      newState = reducer(initialState, {
+        type: actions.CHANGE_VIEW,
+        view: {
+          type: 'form',
+          version: '2.0',
+          cells: [{
+            id: 'bar',
+            model: {
+              type: 'string'
+            },
+            internal: true
+          }]
+        }
+      })
+    })
+
+    it('should return the view', function () {
+      expect(newState.view).to.eql({
+        type: 'form',
+        version: '2.0',
+        cells: [{
+          id: 'bar',
+          internal: true,
+          model: '_internal.bar'
+        }]
+      })
+    })
+
+    it('should update the model', function () {
+      expect(newState.model).to.eql({
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'object'
+          },
+          _internal: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** an issue in the `CHANGE_VIEW` reducer where it didn't update the model properly when the view contained internal models.
