### PR TITLE
Fix publish to install before building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 - npm install -g coveralls pr-bumper@^1.0.0
 
 install:
-- $(npm root -g)/pr-bumper/.travis/maybe-install.sh
+- npm install
 
 before_script:
 - npm run build


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** tagged branches to install before trying to build so they don't fail to publish.
