### PR TITLE
Support arbitrary form values in conditions

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -194,8 +194,9 @@ export const actionReducers = {
     if (state) {
       let initialValue = state.value || {}
       if (state.baseModel) {
+        initialValue = recursiveClean(initialValue, state.baseModel)
         state.baseModel = getDereferencedModelSchema(state.baseModel)
-        state.model = evaluateConditions(state.baseModel, recursiveClean(initialValue, state.baseModel))
+        state.model = evaluateConditions(state.baseModel, initialValue, undefined, initialValue)
         // leave this undefined to force consumers to go through the proper CHANGE_VALUE channel
         // for value changes
         state.value = undefined
@@ -244,7 +245,7 @@ export const actionReducers = {
     }
 
     // Evaluate and remove model conditions so consumers don't have to parse conditions
-    newState.model = evaluateConditions(newState.baseModel, state.value)
+    newState.model = evaluateConditions(newState.baseModel, state.value, undefined, state.value)
 
     return _.defaults(newState, state)
   },
@@ -284,7 +285,7 @@ export const actionReducers = {
     if (!_.isEqual(state.baseModel, normalized.model)) {
       Object.assign(newState, {
         baseModel: normalized.model,
-        model: evaluateConditions(normalized.model, state.value)
+        model: evaluateConditions(normalized.model, state.value, undefined, state.value)
       })
     }
 
@@ -344,7 +345,7 @@ export const actionReducers = {
     // If the value actually changed then we need to re-compute the model and view
     // so conditionals are correctly applied
     if (newState.valueChangeSet.size > 0) {
-      const newModel = evaluateConditions(state.baseModel, newState.value)
+      const newModel = evaluateConditions(state.baseModel, newState.value, undefined, newState.value)
       newState.model = _.isEqual(state.model, newModel) ? state.model : newModel
 
       if (state.baseView) {

--- a/src/utils/conditionals.js
+++ b/src/utils/conditionals.js
@@ -30,10 +30,6 @@ const getExpectedValue = function (formValue, expected) {
 
 const predicateWrapper = function (predicate) {
   return function (value, expected, formValue) {
-    if (expected === undefined) {
-      throw new Error('expected value is undefined')
-    }
-
     if (Array.isArray(expected)) {
       return predicate(value, expected.map((item) => getExpectedValue(formValue, item)))
     }

--- a/tests/view-conditionals-test.js
+++ b/tests/view-conditionals-test.js
@@ -530,4 +530,76 @@ describe('views with conditionals', function () {
       })
     })
   })
+
+  describe('condition referencing form values', function () {
+    let condition, view
+    beforeEach(function () {
+      condition = {}
+
+      view = {
+        type: 'form',
+        version: '2.0',
+        cells: [{
+          model: 'foo',
+          conditions: [{
+            if: [{
+              'foo': condition
+            }]
+          }]
+        }]
+      }
+    })
+
+    describe('simple expectation', function () {
+      beforeEach(function () {
+        condition['equals'] = '#/bar'
+      })
+
+      it('should evaluate true when condition is met', function () {
+        const value = {foo: 'foo', bar: 'foo'}
+        expect(evaluate(view, value)).to.eql({
+          type: 'form',
+          version: '2.0',
+          cells: [{
+            model: 'foo'
+          }]
+        })
+      })
+
+      it('should evaluate false when condition is not met', function () {
+        const value = {foo: 'bar', bar: 'foo'}
+        expect(evaluate(view, value)).to.eql({
+          type: 'form',
+          version: '2.0',
+          cells: []
+        })
+      })
+    })
+
+    describe('array expectation', function () {
+      beforeEach(function () {
+        condition['isEither'] = ['#/bar', 'bar']
+      })
+
+      it('should evaluate true when condition is met', function () {
+        const value = {foo: 'bar', bar: 'baz'}
+        expect(evaluate(view, value)).to.eql({
+          type: 'form',
+          version: '2.0',
+          cells: [{
+            model: 'foo'
+          }]
+        })
+      })
+
+      it('should evaluate false when condition is not met', function () {
+        const value = {foo: 'boo', bar: 'foo'}
+        expect(evaluate(view, value)).to.eql({
+          type: 'form',
+          version: '2.0',
+          cells: []
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* Support arbitrary form values in conditions. All condition predicates now have a 3rd positional parameter which is the form value.
