### PR TITLE
Allow new properties in v2 schema

### DIFF
--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -222,6 +222,10 @@ const definitions = {
         type: 'boolean'
       },
 
+      isSection: {
+        type: 'boolean'
+      },
+
       // The user-visible label for this cell
       label: {
         type: 'string'
@@ -265,6 +269,11 @@ const definitions = {
           {'$ref': '#/definitions/textareaRenderer'},
           {'$ref': '#/definitions/urlRenderer'}
         ]
+      },
+
+      // user defined identification string
+      tag: {
+        type: 'string'
       },
 
       // Transforms to perform on read/write


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* Adds `isSection` and `tag` properties to v2 schema. Upcoming bunsen feature will utilize those extra properties to force a cell as a section without requiring a `label` or `collapsible` to be set. `tag` will allow users to defined an id they can use as a reference.
