### PR TITLE
add each key option for array containers

### DIFF
--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -52,6 +52,11 @@ const definitions = {
         items: {
           '$ref': '#/definitions/cell'
         }
+      },
+
+      // Override default `@index` key for each helper
+      eachKey: {
+        type: 'string'
       }
     }
   },


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Add `eachKey` to `arrayOptions` view schema. This allows the consumer to pick a better key for the `{{#each key=eachKey}}` used in array containers