### PR TITLE
Allow classNames to be a string

### DIFF
--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -110,29 +110,33 @@ const definitions = {
 
       // class names to put on DOM elements
       classNames: {
-        additionalProperties: false,
-        properties: {
-          // the class name for the div that is the cell itself
-          cell: {
-            type: 'string'
-          },
+        oneOf: [{
+          type: 'string'
+        }, {
+          additionalProperties: false,
+          properties: {
+            // the class name for the div that is the cell itself
+            cell: {
+              type: 'string'
+            },
 
-          // the class name for the field (the wrapper for the input)
-          field: {
-            type: 'string'
-          },
+            // the class name for the field (the wrapper for the input)
+            field: {
+              type: 'string'
+            },
 
-          // the class name for the label of the cell
-          label: {
-            type: 'string'
-          },
+            // the class name for the label of the cell
+            label: {
+              type: 'string'
+            },
 
-          // the class name for the value of the cell (generally an input)
-          value: {
-            type: 'string'
-          }
-        },
-        type: 'object'
+            // the class name for the value of the cell (generally an input)
+            value: {
+              type: 'string'
+            }
+          },
+          type: 'object'
+        }]
       },
 
       // cells that are nested within this cell


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

`classNames` originally accepted only an object but support a new feature in Bunsen, this also needs to accept strings.