### PR TITLE
Adding cellId property to cell definition

### DIFF
--- a/src/validator/view-schemas/v2.js
+++ b/src/validator/view-schemas/v2.js
@@ -239,6 +239,11 @@ const definitions = {
       isSection: {
         type: 'boolean'
       },
+      
+      // ID used to reference the cell externally
+      cellId: {
+        type: 'string'
+      },
 
       // The user-visible label for this cell
       label: {


### PR DESCRIPTION
This will be required to reference a cell externally outside of Bunsen.

### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [X] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Added cellId property to cell definition
